### PR TITLE
Default path of rules.js must be relative to where the currently executing script resides in

### DIFF
--- a/bin/atomize
+++ b/bin/atomize
@@ -15,7 +15,7 @@ if (process.argv.slice(2).length === 0 || params.help) {
     return;
 }
 
-var rules = path.resolve('src', 'rules.js');
+var rules = path.resolve(__dirname, '../src/rules.js');
 var srcFiles = params._ || []; 
 var outfile = params.o || params.outfile;
 var options = {}; // TODO


### PR DESCRIPTION
Reference: http://nodejs.org/docs/latest/api/globals.html#globals_dirname

@thierryk @src-code 
