### PR TITLE
Forcing configObjs to be an array

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -20,6 +20,10 @@ module.exports = function (configObjs, options) {
         banner: ''
     }, options);
 
+    if (!_.isArray(configObjs)) {
+        configObjs = [configObjs];
+    }
+
     if (configObjs.length === 0) {
         throw new Error('No configuration provided.');
     }


### PR DESCRIPTION
Fixing an issue that came up with grunt-atomizer... @renatoi 
