### PR TITLE
Validate hex strings containing uppercase digits, emit warning

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -236,7 +236,10 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                     value = Math.round(matchVal.numerator / matchVal.denominator * 100 * 10000) / 10000 + '%';
                 }
                 if (matchVal.hex) {
-                    if (matchVal.alpha) {
+                    if (matchVal.hex !== matchVal.hex.toLowerCase()) {
+                        console.warn('Warning: Only lowercase hex digits are accepted. No rules will be generated for `' + matchVal.input + '`');
+                        value = null;
+                    } else if (matchVal.alpha) {
                         rgb = utils.hexToRgb(matchVal.hex);
                         value = [
                             'rgba(',

--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -71,7 +71,7 @@ var GRAMMAR = {
     'PARAMS'        : '\\((?<params>[^)]*)\\)',
     'NUMBER'        : '-?[0-9]+(?:\.[0-9]+)?|\\.[0-9]+',
     'UNIT'          : '[a-zA-Z%]+',
-    'HEX'           : '#[0-9a-f]{3}(?:[0-9a-f]{3})?',
+    'HEX'           : '#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?',
     'ALPHA'         : '\\.\\d{1,2}',
     'IMPORTANT'     : '!',
     // https://regex101.com/r/mM2vT9/8

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -342,7 +342,7 @@ describe('Atomizer()', function () {
         it ('returns css by reading an array of class names', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['Translate3d(0,0,0)', 'Bd(0)', 'Bd(n)', 'C(red)', 'Cnt(cq):h::b', 'Cnt(oq)::b', 'Px(inh)', 'Trsdu(.3s)', 'sibling:c+D(n)', 'End(0)', 'Ta(start)', 'Ta(end)', 'Bgc(#fff.4)', 'Bgc(#fff)', 'P(55px)', 'H(100%)', 'M(a)', 'test:h>Op(1):h', 'test:h_Op(1):h', 'Op(1)', 'Op(1)!', 'D(n)!', 'C(#333)', 'C(#333):li', 'Mt(-10px)', 'W(1/3)', 'Bgz(45px)']
+                classNames: ['Translate3d(0,0,0)', 'Bd(0)', 'Bd(n)', 'C(red)', 'Cnt(cq):h::b', 'Cnt(oq)::b', 'Px(inh)', 'Trsdu(.3s)', 'sibling:c+D(n)', 'End(0)', 'Ta(start)', 'Ta(end)', 'Bgc(#fff.4)', 'Bgc(#fff)', 'P(55px)', 'H(100%)', 'M(a)', 'test:h>Op(1):h', 'test:h_Op(1):h', 'Op(1)', 'Op(1)!', 'D(n)!', 'C(#333)', 'C(#333):li', 'Mt(-10px)', 'W(1/3)', 'Bgz(45px)', 'C(#FFF)']
             };
             var expected = [
                 '.Bd\\(0\\) {',

--- a/tests/lib/grammar.js
+++ b/tests/lib/grammar.js
@@ -25,4 +25,10 @@ describe('Grammar()', function () {
             expect(Grammar.getPseudo('::before')).to.equal('::before');
         });
     });
+    describe('matchValue()', function () {
+        it('parses uppercase and lowercase hex', function () {
+            expect(Grammar.matchValue('#abc123')['hex']).to.equal('#abc123');
+            expect(Grammar.matchValue('#ABC123')['hex']).to.equal('#ABC123');
+        });
+    });
 });


### PR DESCRIPTION
Currently, the grammar does not support case insensitive hex.
So, `#fff` parses while `#FFF` does not.  This fixes that.
Unfortunately, because the HEX definition is nested inside of
a large `String.join()`, we can't just add a case insensitive flag.
Without refactoring the entire grammar, this seems like the most
expedient fix.

@src-code /cc @ajcrews