### PR TITLE
JSS: Processing main block before media query blocks

### DIFF
--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -126,7 +126,6 @@ JSS.jssToCss = function (jss/*:Jss*/, options/*:Options*/) {
     var extracted/*:Extracted*/;
     var stylesheet/*:Stylesheet*/;
     var tab = options && options.tabWidth && utils.repeatString(' ', parseInt(options.tabWidth, 10)) || utils.repeatString(' ', 2);
-    var ruleTab = '';
 
     // flatten nested selectors
     jss = JSS.flattenSelectors({}, jss);
@@ -141,19 +140,13 @@ JSS.jssToCss = function (jss/*:Jss*/, options/*:Options*/) {
     stylesheet = JSS.extractedToStylesheet(extracted);
 
     // finally, write css
+    // First write the main block
+    JSS.writeBlockToCSS(css, stylesheet.main, tab);
+    // Next write any media query blocks
     for (var block in stylesheet) {
         if (block !== 'main') {
-            ruleTab = tab;
             css.push(block + ' {');
-        }
-        for (var selector in stylesheet[block]) {
-            css.push(ruleTab + selector + ' {');
-            for (var prop in stylesheet[block][selector]) {
-                css.push(ruleTab + tab + prop + ': ' + stylesheet[block][selector][prop] + ';');
-            }
-            css.push(ruleTab + '}');
-        }
-        if (block !== 'main') {
+            JSS.writeBlockToCSS(css, stylesheet[block], tab, tab);
             css.push('}');
         }
     }
@@ -161,6 +154,17 @@ JSS.jssToCss = function (jss/*:Jss*/, options/*:Options*/) {
     css = css.length > 0 ? css.join('\n') + '\n' : '';
 
     return css;
+};
+
+JSS.writeBlockToCSS = function (css, block, tab, indent) {
+    indent = indent || '';
+    for (var selector in block) {
+        css.push(indent + selector + ' {');
+        for (var prop in block[selector]) {
+            css.push(indent + tab + prop + ': ' + block[selector][prop] + ';');
+        }
+        css.push(indent + '}');
+    }
 };
 
 module.exports = JSS;

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -281,6 +281,7 @@ describe('JSS', function () {
             ].join('\n');
             expect(result).to.equal(expected);
         });
+
         it('should return CSS with combined selectors given a CSS Object', function () {
             var result = JSS.jssToCss({
                 'body': {
@@ -329,6 +330,30 @@ describe('JSS', function () {
                 '  }',
                 '  #atomic .test6 {',
                 '    background: black;',
+                '  }',
+                '}\n'
+            ].join('\n');
+            expect(result).to.equal(expected);
+        });
+
+        it('should return CSS with media query blocks placed after the main block', function () {
+            var result = JSS.jssToCss({
+                '.W\(100\%\)--sm': {
+                    '@media screen and (max-width: 900px)': {
+                        width: '100%'
+                    }
+                },
+                '.W\(1\/3\)': {
+                    width: '33.3333%'
+                }
+            });
+            var expected = [
+                '.W\(1\/3\) {',
+                '  width: 33.3333%;',
+                '}',
+                '@media screen and (max-width: 900px) {',
+                '  .W\(100\%\)--sm {',
+                '    width: 100%;',
                 '  }',
                 '}\n'
             ].join('\n');


### PR DESCRIPTION
Addressing issue #260.  Prioritizing the processing of the main block before attempting to process any media query blocks.  

@renatoi @thierryk