### PR TITLE
Disallowing param-to-value for Trsp

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -2537,7 +2537,7 @@ module.exports = [
         "type": "pattern",
         "name": "Transition property",
         "matcher": "Trsp",
-        "allowParamToValue": true,
+        "allowParamToValue": false,
         "styles": {
             "transition-property": "$0"
         },


### PR DESCRIPTION
As mentioned in issue #238, `Trsp` claims to allow param-to-value, but in reality it doesn't work since the strings are interpreted by Atomizer as custom values (since they are not numeric and don't offer a unit suffix.)  Updating the rule to reflect this reality.

Will need to update the docs site after this one's merged.

fyi @thierryk @renatoi @pankajparashar @soluml 