### PR TITLE
Adding support for @supports, fixing LineClamp for FF49+

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -250,7 +250,10 @@ module.exports = [
             "[class*=LineClamp]": {
                 "display": "-webkit-box",
                 "-webkit-box-orient": "vertical",
-                "overflow": "hidden"
+                "overflow": "hidden",
+                "@supports (display:-moz-box)": {
+                    "display": "block"
+                }
             },
             "a[class*=LineClamp]": {
                 "display": "inline-block",

--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -20,7 +20,7 @@ JSS.flattenSelectors = function (newJss/*:Jss*/, jss/*:Jss*/, parent/*:string*/)
             // prop is not a prop
             if (typeof value === 'object') {
                 // prop is a media query
-                if (/^@media/.test(prop)) {
+                if (/^@media|@supports/.test(prop)) {
                     if (!newJss[prop]) {
                         newJss[prop] = {};
                     }
@@ -53,7 +53,7 @@ JSS.extractProperties = function (extracted/*:Extracted*/, jss/*:JssFlat*/, bloc
     for (var selector in jss) {
         props = jss[selector];
         // if selector is a media query
-        if (/^@media/.test(selector)) {
+        if (/^@media|@supports/.test(selector)) {
             JSS.extractProperties(extracted, props, selector);
         } else {
             for (prop in props) {


### PR DESCRIPTION
Adding support for `@supports` to JSS, so that we can fix `LineClamp()` in FF 49+ (see issue #272).

fyi @fabianuribe @thierryk @renatoi 