### PR TITLE
feat(grammar): accept hyphenated-prop name

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -64,7 +64,7 @@ var GRAMMAR = {
     'PARENT'        : '[a-zA-Z][-_a-zA-Z0-9]+?',
     'PARENT_SEP'    : '[>_+]',
     // all characters allowed to be a prop
-    'PROP'          : '[A-Za-z0-9]+',
+    'PROP'          : '[-A-Za-z0-9]+',
     // all character allowed to be in values
     'VALUES'        : '[-_,.#$/%0-9a-zA-Z]+',
     'FRACTION'      : '(?<numerator>[0-9]+)\\/(?<denominator>[1-9](?:[0-9]+)?)',

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -42,6 +42,21 @@ describe('Atomizer()', function () {
             var expected = ['Pos(r)', 'Ov(h)', 'H(0)'];
             expect(result).to.deep.equal(expected);
         });
+        it('properly resolves custom classnames with hyphen, in custom rules.js', function () {
+            var rules = [{
+                type: 'pattern',
+                name: 'Font Size',
+                matcher: 'f-z',
+                styles: {
+                    'font-size': '$0'
+                }
+            }];
+            var atomizer = new Atomizer();
+            atomizer.addRules(rules);
+            var result = atomizer.findClassNames('<div class="Fz(RWD-fontSize) f-z(RWD-fontSize)"></div>');
+            var expected = ['Fz(RWD-fontSize)', 'f-z(RWD-fontSize)'];
+            expect(result).to.deep.equal(expected);
+        });
         it('properly finds Atomic classnames inside Dust template conditionals', function () {
             var atomizer = new Atomizer();
             var result = atomizer.findClassNames('<div class="Pos(r) Ov(h) H(0) {?foo}D(n){/foo}"></div>');


### PR DESCRIPTION
if custom `rules.js` specifies `"font-size"` matcher as `f-z`
and `f-z(16px)` is used, following css should be generated
```css
.f-z\(16px\) {
    font-size: 16px;
}
```
cc/ @renatoi 