### PR TITLE
Sorting classnames in config

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -125,7 +125,7 @@ Atomizer.prototype.findClassNames = function (src/*:string*/)/*:string[]*/ {
 Atomizer.prototype.getConfig = function (classNames/*:string[]*/, config/*:AtomizerConfig*/)/*:AtomizerConfig*/ {
     config = config || { classNames: [] };
     // merge classnames with config
-    config.classNames = _.union(classNames || [], config.classNames);
+    config.classNames = _.union(classNames || [], config.classNames).sort();
     return config;
 };
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -27,7 +27,7 @@ utils.hexToRgb = function (hex/*:string*/)/*:Rgb*/ {
  */
 utils.handleMergeArrays = function (a, b) {
     if (_.isArray(a) && _.isArray(b)) {
-        return _.union(a, b);
+        return _.union(a, b).sort();
     }
 };
 

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -243,7 +243,7 @@ describe('Atomizer()', function () {
                 custom: {
                     heading: '80px'
                 },
-                classNames: ['P(55px)', 'D(b)', 'M(10px)', 'D(ib)']
+                classNames: ['D(b)', 'D(ib)', 'M(10px)', 'P(55px)']
             };
             var result = atomizer.getConfig(classNames, existingConfig);
             expect(result).to.deep.equal(expected);

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -73,7 +73,7 @@ describe('utils', function () {
                 classNames: ['C-#333', 'D-ib']
             };
             var expected = {
-                classNames: ['D-ib', 'Bd-foo', 'D-n!', 'C-#333']
+                classNames: ['Bd-foo', 'C-#333', 'D-ib', 'D-n!']
             };
             var result = utils.mergeConfigs([config1, config2, config3]);
 


### PR DESCRIPTION
For larger codebases, it's kind of nice to have things sorted so you can quickly see where there's unnecessarily duplicative classes being created.