### PR TITLE
Media query blocks in output CSS aren't ordered

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -534,7 +534,9 @@ Atomizer.prototype.getCss = function (config/*:AtomizerConfig*/, options/*:CSSOp
     });
 
     // convert JSS to CSS
-    content = options.banner + JSS.jssToCss(jss);
+    content = options.banner + JSS.jssToCss(jss, {
+      breakPoints: breakPoints
+    });
 
     // fix the comma problem in Absurd
     content = Atomizer.replaceConstants(content, options.rtl);

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -346,7 +346,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                                 if (!config.hasOwnProperty('breakPoints') || !config.breakPoints.hasOwnProperty(bp)) {
                                     return;
                                 }
-                                treeo.declarations[config.breakPoints[bp]] = {};
+                                treeo.declarations[config.breakPoints[bp]] = treeo.declarations[config.breakPoints[bp]] || {};
                                 treeo.declarations[config.breakPoints[bp]][prop] = treeo.declarations[prop].replace('$' + index, value[bp]);
                             });
                             // handle default value in the custom class

--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -62,7 +62,7 @@ JSS.extractProperties = function (extracted/*:Extracted*/, jss/*:JssFlat*/, bloc
                 }
                 extracted[block].push({
                     selector: selector,
-                    prop: prop, 
+                    prop: prop,
                     value: props[prop]
                 });
             }
@@ -143,12 +143,11 @@ JSS.jssToCss = function (jss/*:Jss*/, options/*:Options*/) {
     // First write the main block
     JSS.writeBlockToCSS(css, stylesheet.main, tab);
     // Next write any media query blocks
-    for (var block in stylesheet) {
-        if (block !== 'main') {
-            css.push(block + ' {');
-            JSS.writeBlockToCSS(css, stylesheet[block], tab, tab);
-            css.push('}');
-        }
+    for (var label in options.breakPoints) {
+        var block = options.breakPoints[label];
+        css.push(block + ' {');
+        JSS.writeBlockToCSS(css, stylesheet[block], tab, tab);
+        css.push('}');
     }
 
     css = css.length > 0 ? css.join('\n') + '\n' : '';

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -750,6 +750,11 @@ describe('Atomizer()', function () {
                 classNames: ['D(n)--sm', 'P(foo)--sm', 'Foo--2xs', 'Bar(10px)--sm']
             };
             var expected = [
+                '@media(min-width:300px) {',
+                '  .Foo--2xs {',
+                '    foo: bar;',
+                '  }',
+                '}',
                 '@media(min-width:400px) {',
                 '  .D\\(n\\)--sm {',
                 '    display: none;',
@@ -759,11 +764,6 @@ describe('Atomizer()', function () {
                 '  }',
                 '  .Bar\\(10px\\)--sm {',
                 '    bar: 10px;',
-                '  }',
-                '}',
-                '@media(min-width:300px) {',
-                '  .Foo--2xs {',
-                '    foo: bar;',
                 '  }',
                 '}\n'
             ].join('\n');

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -300,6 +300,98 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('returns expected css for custom classes with break points (Py)', function () {
+            // set rules here so if helper change, we don't fail the test
+            var atomizer = new Atomizer();
+            var config = {
+                breakPoints: {
+                    sm: '@media screen and (min-width:700px)',
+                    md: '@media screen and (min-width:999px)',
+                    lg: '@media screen and (min-width:1200px)'
+                },
+                custom: {
+                    'Py($gutter)': {
+                        default: '10px',
+                        sm: '16px',
+                        md: '20px',
+                        lg: '24px'
+                    }
+                },
+                classNames: ['Py($gutter)']
+            };
+            var expected = [
+                '.Py\\(\\$gutter\\) {',
+                '  padding-top: 10px;',
+                '  padding-bottom: 10px;',
+                '}',
+                '@media screen and (min-width:700px) {',
+                '  .Py\\(\\$gutter\\) {',
+                '    padding-top: 16px;',
+                '    padding-bottom: 16px;',
+                '  }',
+                '}',
+                '@media screen and (min-width:999px) {',
+                '  .Py\\(\\$gutter\\) {',
+                '    padding-top: 20px;',
+                '    padding-bottom: 20px;',
+                '  }',
+                '}',
+                '@media screen and (min-width:1200px) {',
+                '  .Py\\(\\$gutter\\) {',
+                '    padding-top: 24px;',
+                '    padding-bottom: 24px;',
+                '  }',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+        it ('returns expected css for custom classes with break points (Px)', function () {
+            // set rules here so if helper change, we don't fail the test
+            var atomizer = new Atomizer();
+            var config = {
+                breakPoints: {
+                    sm: '@media screen and (min-width:700px)',
+                    md: '@media screen and (min-width:999px)',
+                    lg: '@media screen and (min-width:1200px)'
+                },
+                custom: {
+                    'Px($gutter)': {
+                        default: '10px',
+                        sm: '16px',
+                        md: '20px',
+                        lg: '24px'
+                    }
+                },
+                classNames: ['Px($gutter)']
+            };
+            var expected = [
+                '.Px\\(\\$gutter\\) {',
+                '  padding-left: 10px;',
+                '  padding-right: 10px;',
+                '}',
+                '@media screen and (min-width:700px) {',
+                '  .Px\\(\\$gutter\\) {',
+                '    padding-left: 16px;',
+                '    padding-right: 16px;',
+                '  }',
+                '}',
+                '@media screen and (min-width:999px) {',
+                '  .Px\\(\\$gutter\\) {',
+                '    padding-left: 20px;',
+                '    padding-right: 20px;',
+                '  }',
+                '}',
+                '@media screen and (min-width:1200px) {',
+                '  .Px\\(\\$gutter\\) {',
+                '    padding-left: 24px;',
+                '    padding-right: 24px;',
+                '  }',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
         it ('returns expected css for custom classes with break points with missing breakPoints', function () {
             // set rules here so if helper change, we don't fail the test
             var atomizer = new Atomizer();

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -31,13 +31,13 @@ describe('JSS', function () {
                 '#atomic': {
                     '.test10': {
                         'display': 'block',
-                        '@media(min-width:400px)': {
+                        '@media screen and (min-width:400px)': {
                             'background': 'black'
                         }
                     },
                     '.test11': {
                         'display': 'none',
-                        '@media(min-width:400px)': {
+                        '@media screen and (min-width:400px)': {
                             'color': 'white'
                         }
                     }
@@ -59,7 +59,7 @@ describe('JSS', function () {
                 '#atomic .test10': {
                     'display': 'block'
                 },
-                '@media(min-width:400px)': {
+                '@media screen and (min-width:400px)': {
                     '#atomic .test10': {
                         background: 'black'
                     },
@@ -92,7 +92,7 @@ describe('JSS', function () {
                 '#atomic .test10': {
                     'display': 'block'
                 },
-                '@media(min-width:400px)': {
+                '@media screen and (min-width:400px)': {
                     '#atomic .test10': {
                         background: 'black'
                     },
@@ -137,7 +137,7 @@ describe('JSS', function () {
                         value: 'none'
                     }
                 ],
-                '@media(min-width:400px)': [
+                '@media screen and (min-width:400px)': [
                     {
                         selector: '#atomic .test10',
                         prop: 'background',
@@ -168,7 +168,7 @@ describe('JSS', function () {
                         value: 'white'
                     }
                 ],
-                '@media(min-width:400px)': [
+                '@media screen and (min-width:400px)': [
                     {
                         selector: '.test1',
                         prop: 'background',
@@ -182,7 +182,7 @@ describe('JSS', function () {
                 ]
             });
             var expected = {
-                '@media(min-width:400px)': [
+                '@media screen and (min-width:400px)': [
                     {
                         selector: '.test1, #atomic .test11',
                         prop: 'background',
@@ -213,7 +213,7 @@ describe('JSS', function () {
     describe('extractedToStylesheet()', function () {
         it('should return a stylesheet object given an extracted object', function () {
             var result = JSS.extractedToStylesheet({
-                '@media(min-width:400px)': [
+                '@media screen and (min-width:400px)': [
                     {
                         selector: '.test1, #atomic .test11',
                         prop: 'background',
@@ -239,7 +239,7 @@ describe('JSS', function () {
                 ]
             });
             var expected = {
-                '@media(min-width:400px)': {
+                '@media screen and (min-width:400px)': {
                     '.test1, #atomic .test11': {
                         background: 'black'
                     }
@@ -261,20 +261,25 @@ describe('JSS', function () {
                     'color': 'red',
                     'font-size': '10px'
                 },
-                '.bar': {
-                    '@media(min-width:400px)': {
+                '.bar--sm': {
+                    '@media screen and (min-width:400px)': {
                         'background': 'white'
                     }
                 }
-            }, {tabWidth: 4});
+            }, {
+                tabWidth: 4,
+                breakPoints: {
+                    sm: '@media screen and (min-width:400px)'
+                }
+            });
             var expected = [
                 '.foo {',
                 '    background: black;',
                 '    color: red;',
                 '    font-size: 10px;',
                 '}',
-                '@media(min-width:400px) {',
-                '    .bar {',
+                '@media screen and (min-width:400px) {',
+                '    .bar--sm {',
                 '        background: white;',
                 '    }',
                 '}\n'
@@ -296,7 +301,7 @@ describe('JSS', function () {
                     'background': 'white'
                 },
                 '.test3': {
-                    '@media(min-width:400px)': {
+                    '@media screen and (min-width:400px)': {
                         'background': 'white'
                     }
                 },
@@ -307,10 +312,14 @@ describe('JSS', function () {
                 },
                 '#atomic': {
                     '.test6': {
-                        '@media(min-width:400px)': {
+                        '@media screen and (min-width:400px)': {
                             'background': 'black'
                         }
                     },
+                }
+            }, {
+                breakPoints: {
+                    sm: '@media screen and (min-width:400px)'
                 }
             });
             var expected = [
@@ -324,7 +333,7 @@ describe('JSS', function () {
                 '.test2 {',
                 '  background: white;',
                 '}',
-                '@media(min-width:400px) {',
+                '@media screen and (min-width:400px) {',
                 '  .test3 {',
                 '    background: white;',
                 '  }',
@@ -346,6 +355,10 @@ describe('JSS', function () {
                 '.W\(1\/3\)': {
                     width: '33.3333%'
                 }
+            }, {
+                breakPoints: {
+                    sm: '@media screen and (max-width: 900px)'
+                }
             });
             var expected = [
                 '.W\(1\/3\) {',
@@ -356,6 +369,47 @@ describe('JSS', function () {
                 '    width: 100%;',
                 '  }',
                 '}\n'
+            ].join('\n');
+            expect(result).to.equal(expected);
+        });
+
+        it('should return CSS with media query blocks ordered by media query not by property name', function () {
+            var result = JSS.jssToCss({
+                '.C\(#000\)--md': {
+                    '@media screen and \(min-width: 1000px\)': {
+                        color: '#000'
+                    },
+                },
+                '.W\(100px\)--sm': {
+                    '@media screen and \(min-width: 600px\)': {
+                        width: '100px',
+                    },
+                },
+                '.W\(200px\)--md': {
+                    '@media screen and \(min-width: 1000px\)': {
+                        width: '200px',
+                    },
+                },
+            }, {
+                breakPoints: {
+                    'sm': '@media screen and (min-width: 600px)',
+                    'md': '@media screen and (min-width: 1000px)',
+                }
+            });
+            var expected = [
+                '@media screen and (min-width: 600px) {',
+                '  .W\(100px\)--sm {',
+                '    width: 100px;',
+                '  }',
+                '}',
+                '@media screen and (min-width: 1000px) {',
+                '  .C\(#000\)--md {',
+                '    color: #000;',
+                '  }',
+                '  .W\(200px\)--md {',
+                '    width: 200px;',
+                '  }',
+                '}\n',
             ].join('\n');
             expect(result).to.equal(expected);
         });


### PR DESCRIPTION
# The problem

Given an input of:

```
.element {
    @media screen and (min-width: 1000px) {
        color: white;
    }
}

.element {
    @media screen and (min-width: 600px) {
        width: 200px;
    }
}

.element {
    @media screen and (min-width: 1000px) {
        width: 500px;
    }
}
```

You currently get an output of:

```
@media screen and (min-width: 1000px) {
    .element {
        color: white;
        width: 500px;
    }
}

@media screen and (min-width: 600px) {
    .element {
        width: 200px;
    }
}
```

This we think is because the first 1000px entry was before the first 600px entry, and they're grouped up.

At a screen width of more than 1000px now, your element has a width of 200px instead of the expected 500px, because of the order of the media query blocks.

# What is expected?

We expect that the smallest media query blocks are higher in the CSS file than the larger ones so that the larger ones override the smaller ones.

The names of the breakpoints are arbitrary enough that it's difficult to sort by them. You could sort by the actual breakpoint values, but that would be quite complex, so as a compromise we decided to order them in the same order as the breakpoints you configure.