### PR TITLE
Only generate CSS for media query if matches found

### DIFF
--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -145,9 +145,11 @@ JSS.jssToCss = function (jss/*:Jss*/, options/*:Options*/) {
     // Next write any media query blocks
     for (var label in options.breakPoints) {
         var block = options.breakPoints[label];
-        css.push(block + ' {');
-        JSS.writeBlockToCSS(css, stylesheet[block], tab, tab);
-        css.push('}');
+        if (stylesheet[block]) {
+            css.push(block + ' {');
+            JSS.writeBlockToCSS(css, stylesheet[block], tab, tab);
+            css.push('}');
+        }
     }
 
     css = css.length > 0 ? css.join('\n') + '\n' : '';

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -431,7 +431,7 @@ describe('JSS', function () {
                 '  .C\(#000\)--md {',
                 '    color: #000;',
                 '  }'
-                '}\n',
+                '}',
             ].join('\n');
             expect(result).to.equal(expected);
         });

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -431,7 +431,7 @@ describe('JSS', function () {
                 '  .C\(#000\)--md {',
                 '    color: #000;',
                 '  }'
-                '}',
+                '}'
             ].join('\n');
             expect(result).to.equal(expected);
         });

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -413,5 +413,27 @@ describe('JSS', function () {
             ].join('\n');
             expect(result).to.equal(expected);
         });
+        it('should generate media query CSS only if matches found', function () {
+            var result = JSS.jssToCss({
+                '.C\(#000\)--md': {
+                    '@media screen and \(min-width: 1000px\)': {
+                        color: '#000'
+                    },
+                }
+            }, {
+                breakPoints: {
+                    'sm': '@media screen and (min-width: 600px)',
+                    'md': '@media screen and (min-width: 1000px)',
+                }
+            });
+            var expected = [
+                '@media screen and (min-width: 1000px) {',
+                '  .C\(#000\)--md {',
+                '    color: #000;',
+                '  }'
+                '}\n',
+            ].join('\n');
+            expect(result).to.equal(expected);
+        });
     });
 });

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -431,7 +431,7 @@ describe('JSS', function () {
                 '  .C\(#000\)--md {',
                 '    color: #000;',
                 '  }',
-                '}'
+                '}\n'
             ].join('\n');
             expect(result).to.equal(expected);
         });

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -418,7 +418,7 @@ describe('JSS', function () {
                 '.C\(#000\)--md': {
                     '@media screen and \(min-width: 1000px\)': {
                         color: '#000'
-                    },
+                    }
                 }
             }, {
                 breakPoints: {

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -430,7 +430,7 @@ describe('JSS', function () {
                 '@media screen and (min-width: 1000px) {',
                 '  .C\(#000\)--md {',
                 '    color: #000;',
-                '  }'
+                '  }',
                 '}'
             ].join('\n');
             expect(result).to.equal(expected);


### PR DESCRIPTION
Currently we are generating media query block for all breakpoints listing in options
`options.breakPoints[label]` even if we dont have any matches found (resulting in empty block)

Ideally we should only generate media query block when there are matches rule