### PR TITLE
JSS: Don't assume options exist in JSS.jssToCss()

### DIFF
--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -143,7 +143,7 @@ JSS.jssToCss = function (jss/*:Jss*/, options/*:Options*/) {
     // First write the main block
     JSS.writeBlockToCSS(css, stylesheet.main, tab);
     // Next write any media query blocks
-    if (typeof options.breakPoints === 'object') {
+    if (options && typeof options.breakPoints === 'object') {
         for (var label in options.breakPoints) {
             var block = options.breakPoints[label];
             if (block && stylesheet[block]) {


### PR DESCRIPTION
Along with changes in v3.4.3, ensure `options.breakPoints` exists before trying to iterate on its properties. Addresses issue #289 