### PR TITLE
Generate the flex property with custom values from Flx(...)

### DIFF
--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -46,7 +46,6 @@ JSS.flattenSelectors = function (newJss/*:Jss*/, jss/*:Jss*/, parent/*:string*/)
 JSS.extractProperties = function (extracted/*:Extracted*/, jss/*:JssFlat*/, block/*:string*/)/*:Extracted*/ {
     var props;
     var prop;
-    var extract;
 
     block = block || 'main';
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -1122,6 +1122,7 @@ module.exports = [
         },
         "arguments": [{
             "a": "auto",
+            "ini": "initial",
             "n": "none"
         }]
     },

--- a/src/rules.js
+++ b/src/rules.js
@@ -1116,7 +1116,7 @@ module.exports = [
         "type": "pattern",
         "name": "Flex",
         "matcher": "Flx",
-        "allowParamToValue": false,
+        "allowParamToValue": true,
         "styles": {
             "flex": "$0"
         },

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -912,6 +912,22 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('properly handles the flex property', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                classNames: ['Flx(1)', 'Flx(3)']
+            };
+            var expected = [
+                '.Flx\\(1\\) {',
+                '  flex: 1;',
+                '}',
+                '.Flx\\(3\\) {',
+                '  flex: 3;',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
     });
     // -------------------------------------------------------
     // escapeSelector()

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -1,4 +1,4 @@
-/*globals describe,it,afterEach */
+/*globals describe,it */
 'use strict';
 
 var expect = require('chai').expect;

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -915,14 +915,37 @@ describe('Atomizer()', function () {
         it ('properly handles the flex property', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['Flx(1)', 'Flx(3)']
+                classNames: [
+                    'Flx(a)',
+                    'Flx(inh)',
+                    'Flx(ini)',
+                    'Flx(n)',
+                    'Flx(2)',
+                    'Flx(10em)',
+                    'Flx(30px)',
+                ]
             };
             var expected = [
-                '.Flx\\(1\\) {',
-                '  flex: 1;',
+                '.Flx\\(a\\) {',
+                '  flex: auto;',
                 '}',
-                '.Flx\\(3\\) {',
-                '  flex: 3;',
+                '.Flx\\(inh\\) {',
+                '  flex: inherit;',
+                '}',
+                '.Flx\\(ini\\) {',
+                '  flex: initial;',
+                '}',
+                '.Flx\\(n\\) {',
+                '  flex: none;',
+                '}',
+                '.Flx\\(2\\) {',
+                '  flex: 2;',
+                '}',
+                '.Flx\\(10em\\) {',
+                '  flex: 10em;',
+                '}',
+                '.Flx\\(30px\\) {',
+                '  flex: 30px;',
                 '}\n'
             ].join('\n');
             var result = atomizer.getCss(config);

--- a/tests/fixtures/fz.js
+++ b/tests/fixtures/fz.js
@@ -2,4 +2,4 @@ module.exports = function(api) {
     api.add({
         body: { margin: '20px' }
     });
-}
+};

--- a/tests/lib/jss.js
+++ b/tests/lib/jss.js
@@ -1,4 +1,4 @@
-/*globals describe,it,afterEach */
+/*globals describe,it */
 'use strict';
 
 var expect = require('chai').expect;

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -1,4 +1,4 @@
-/*globals describe,it,afterEach */
+/*globals describe,it */
 'use strict';
 
 var expect = require('chai').expect;


### PR DESCRIPTION
@src-code @redonkulus @sfj2 Currently, you cannot generate the required atomic css for the the `flex` property with the exception of `auto` and `none`.

This PR adds `initial` and also the ability to use a value ( 1, 2, 3, 10em, 30px, etc ).

`flex` is a shorthand property, so 

- `Flx(2)` would generate `flex: 4` which is shorthand for `flex-grow: 4`
- `Flx(10px)` would generate `flex: 10px` which is shorthand for `flex-basis: 10px`

We support other shorthand properties, such as `M(0)` and `P(0)` already, so this isn't entirely new ground.

I'm also fixing a few lint errors that I found.