### PR TITLE
Fixing some flex rules names

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -1138,7 +1138,7 @@ module.exports = [
     // flex-shrink
     {
         "type": "pattern",
-        "name": "Flex",
+        "name": "Flex shrink",
         "matcher": "Flxs",
         "allowParamToValue": true,
         "styles": {
@@ -1148,7 +1148,7 @@ module.exports = [
     // flex-basis
     {
         "type": "pattern",
-        "name": "Flex",
+        "name": "Flex basis",
         "matcher": "Flxb",
         "allowParamToValue": true,
         "styles": {


### PR DESCRIPTION
This affects the reference page https://acss.io/reference/