### PR TITLE
Support parsing template literals

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -61,7 +61,7 @@ function flatten(obj) {
 
 // regular grammar to match valid atomic classes
 var GRAMMAR = {
-    'BOUNDARY'      : '(?:^|\\s|"|\'|\{|\})',
+    'BOUNDARY'      : '(?:^|\\s|"|\'|\`|\{|\})',
     'PARENT'        : '[a-zA-Z][-_a-zA-Z0-9]+?',
     'PARENT_SEP'    : '[>_+~]',
     // all characters allowed to be a prop

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -63,6 +63,12 @@ describe('Atomizer()', function () {
             var expected = ['Pos(r)', 'Ov(h)', 'H(0)', 'D(n)'];
             expect(result).to.deep.equal(expected);
         });
+        it('able to finds classnames in template literals', function () {
+          var atomizer = new Atomizer();
+          var result = atomizer.findClassNames('<div class=`Pos(r) Ov(h) H(0) ${foo}`></div>');
+          var expected = ['Pos(r)', 'Ov(h)', 'H(0)'];
+          expect(result).to.deep.equal(expected);
+        });
     });
     describe('addRules()', function () {
         it('throws if a rule with a different definition already exists', function () {


### PR DESCRIPTION
Currently atomizer doesn't support class name in template literals.

Adding into the boundary.

@src-code @redonkulus @renatoi 