### PR TITLE
Keep default original sort logic if match name are different 

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -144,7 +144,17 @@ Atomizer.prototype.sortCSS = function (classNames /*string[]*/) {
                 return _.includes(value, pseudoClass);
             });
           }
-        return getMatchedIndex(a) - getMatchedIndex(b);
+        const aMatches = Grammar.matchValue(a);
+        const bMatches = Grammar.matchValue(b)
+        const aIndex = getMatchedIndex(a);
+        const bIndex = getMatchedIndex(b);
+
+        // remain same default sort logic
+        if (aMatches.named !== bMatches.named) {
+          return a.localeCompare(b);
+        }
+
+        return aIndex - bIndex;
     }
     classNames = classNames.sort(sortPseudoClassNames);
 


### PR DESCRIPTION
This is a regression caused by #334 

We are sorting all class name again after the initial sort, the second sort for pseudo class should only care about the class name with the same atomic selector

let's say

`C(#fff):a` and `C(#000):h` should be sorted by the pseudo order but not
`Op(#fff):a and `C(#000):h` (it should remain the same alphabetical order as the initial sort)

This cause issue that some CSS weight being changed cause the order change.