### PR TITLE
feat(alpha-in-custom): added support for alpha in custom value

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -170,6 +170,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
     var warnings = [];
     var isVerbose = !!this.verbose;
     var classNames = config.classNames;
+    var alphaInName = '';
 
     if (!_.isArray(config.classNames)) { return tree; }
     options = options || {};
@@ -315,6 +316,24 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                         // as value
                         else if (config.custom.hasOwnProperty(matchVal.named)) {
                             value = config.custom[matchVal.named];
+
+                            if (Grammar.matchValue(value).hex === value && matchVal.named !== matchVal.input) {
+                                alphaInName = matchVal.input.replace(matchVal.named, '');
+                                if (alphaInName && alphaInName.match(/\.\d{1,2}/)) {
+                                    rgb = utils.hexToRgb(value);
+                                    value = [
+                                        'rgba(',
+                                        rgb.r,
+                                        ',',
+                                        rgb.g,
+                                        ',',
+                                        rgb.b,
+                                        ',',
+                                        alphaInName,
+                                        ')'
+                                    ].join('');
+                                }
+                            }
                         }
                         // we have custom but we could not find the named class name there
                         else {

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -306,6 +306,27 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('returns expected css for custom classes with alpha transparency only for hex values', function () {
+            // set rules here so if helper change, we don't fail the test
+            var atomizer = new Atomizer();
+            var config = {
+                custom: {
+                    'black': '#000',
+                    'space': '4px'
+                },
+                classNames: ['Bg(black.15)', 'P(space.15)']
+            };
+            var expected = [
+                '.Bg\\(black\\.15\\) {',
+                '  background: rgba(0,0,0,.15);',
+                '}',
+                '.P\\(space\\.15\\) {',
+                '  padding: 4px;',
+                '}\n',
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
         it ('returns expected css for custom classes with break points (Py)', function () {
             // set rules here so if helper change, we don't fail the test
             var atomizer = new Atomizer();


### PR DESCRIPTION
fixes #340

```js
// acss.config.js
module.exports = {
  'custom' : {
     black: '#000'
  }
}
```
```html
// .html
class="Bg(black.15)"
```
```css
// generated css file
/* current behavior */
.Bg\(black\.15\) {
  background: #000;
}
/* future behavior if this RB is merged */
.Bg\(black\.15\) {
  background: rgba(0,0,0,.15);
}
```

Hello team, it would be great to get some thoughts and feedback for this PR. Thank you for your time.

Best!