### PR TITLE
feat(bin/atomizer): writing to outfile only if the content has changed

### DIFF
--- a/bin/atomizer
+++ b/bin/atomizer
@@ -160,12 +160,18 @@ content = atomizer.getCss(config, options);
 // Output the CSS
 var outfile = program.outfile;
 if (outfile) {
-    fs.mkdir(path.dirname(outfile), function (err) {
-        // Fail silently
-        fs.writeFile(path.resolve(outfile), content, function (err) {
-            if (err) throw err;
-            console.log('File ' + chalk.cyan(outfile) + ' created.');
-        });
+    fs.readFile(outfile, {encoding: 'utf-8'}, function(err, data) {
+        if (data === content) {
+            console.log('Content of ' + chalk.cyan(outfile) + ' has not changed.');
+        } else {
+            fs.mkdir(path.dirname(outfile), function (err) {
+                // Fail silently
+                fs.writeFile(path.resolve(outfile), content, function (err) {
+                    if (err) throw err;
+                    console.log('File ' + chalk.cyan(outfile) + ' created.');
+                });
+            });
+        }
     });
 } else {
     process.stdout.write("\n" + content);


### PR DESCRIPTION
In my existing corporate dev workflow there is already a watcher watching the entire directory for any changes and triggering a build. I do not have much control over the mentioned watcher and thought about this change to write to the output file only if the content has changed since the previous write.

Looking forward to your feedback, suggestions. Thanks!