### PR TITLE
Support more font-variant attributes

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -1526,7 +1526,7 @@ module.exports = [
         "matcher": "Fv",
         "allowParamToValue": false,
         "styles": {
-            "font-variant": "$0"
+            "font-variant": "$0 $1"
         },
         "arguments": [{
             "n": "normal",

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -899,7 +899,11 @@ describe('Atomizer()', function () {
         it ('properly handles classnames with optional arguments', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['Skew(90deg)', 'Skew(90deg,45deg)', 'Bdsp(1em)', 'Bdsp(2em,33%)']
+                custom: {
+                    'sc': 'small-caps',
+                    'slz': 'slashed-zero'
+                },
+                classNames: ['Skew(90deg)', 'Skew(90deg,45deg)', 'Bdsp(1em)', 'Bdsp(2em,33%)', 'Fv(sc,slz)']
             };
             var expected = [
                 '.Bdsp\\(1em\\) {',
@@ -907,6 +911,9 @@ describe('Atomizer()', function () {
                 '}',
                 '.Bdsp\\(2em\\,33\\%\\) {',
                 '  border-spacing: 2em 33%;',
+                '}',
+                '.Fv\\(sc\\,slz\\) {',
+                '  font-variant: small-caps slashed-zero;',
                 '}',
                 '.Skew\\(90deg\\) {',
                 '  transform: skew(90deg);',


### PR DESCRIPTION
## Goal

Support syntax like `'Fv(sc,slz)'` could be transpiled to `font-variant: small-caps slashed-zero;',` with ```config.custom: {
                    'sc': 'small-caps',
                    'slz': 'slashed-zero'
                },```
## Relevant issue 

https://github.com/acss-io/atomizer/issues/355

## MDN Docs

https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant