### PR TITLE
Bail out when null values are encountered

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -361,7 +361,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                             treeo.declarations.filter = 'alpha(opacity=' + parseFloat(value, 10) * 100 + ')';
                         }
                     }
-                    if (value !== null) {
+                    if (value !== null && treeo.declarations) {
                         // value could be an object for custom classes with breakPoints
                         // e.g.
                         // 'custom': {

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -871,6 +871,15 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('ignores classnames with invalid arguments', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                classNames: ['P(F,0,V)']
+            };
+            var expected = '';
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
         it ('warns the user if an ambiguous class is provided and verbose flag is true', function (done) {
             var atomizer = new Atomizer({verbose: true});
             var config = {


### PR DESCRIPTION
When invalid classes are encountered such as `P(a,0,c)` which result in null values being generated for some args (they are not custom values), we need to short-circuit the processing of the rest of the values.  Can't short-circuit a `forEach` loop, but can check for `treeo.declarations` being null before trying to reference it further.

Background - This issue came up because of a recent change to Marko templating system.  Marko generates code that looks a little like Atomic classes, but is actually obfuscated function calls.  Normally these would be ignored due to the lack of valid "values" in the string, but they recently switched away from serializing `null` to using a `0` value, which looks "valid" to Atomizer. 

https://github.com/marko-js/marko/pull/1535