### PR TITLE
chore: add typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,14 +10,7 @@ declare module 'atomizer' {
     }
 
     export interface AtomizerRule {
-        allowParamToValue: boolean;
-        arguments?: Record<string, string>[];
-        id?: string;
-        matcher: string;
-        name: string;
-        shorthand?: boolean;
-        styles: Record<string, string>;
-        type: string;
+        [key: string]: any;
     }
 
     export interface CSSOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'atomizer' {
     export interface AtomizerConfig {
-        custom?: Record<string, string>;
+        custom?: Record<string, string | Record<string, string>>;
         breakPoints?: Record<string, string>;
         classNames?: string[];
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,49 @@
+declare module 'atomizer' {
+    export interface AtomizerConfig {
+        custom?: Record<string, string>;
+        breakPoints?: Record<string, string>;
+        classNames?: string[];
+    }
+
+    export interface AtomizerOptions {
+        verbose?: boolean;
+    }
+
+    export interface AtomizerRule {
+        allowParamToValue: boolean;
+        arguments?: Record<string, string>[];
+        id?: string;
+        matcher: string;
+        name: string;
+        shorthand?: boolean;
+        styles: Record<string, string>;
+        type: string;
+    }
+
+    export interface CSSOptions {
+        banner?: string;
+        helpersNamespace?: string;
+        ie?: boolean;
+        namespace?: string;
+        rtl?: boolean;
+    }
+
+    export default class {
+        public static escapeSelector: (str: string) => string;
+        public static replaceConstants: (str: string, rtl: boolean) => string;
+
+        constructor(options?: AtomizerOptions, rules?: AtomizerRule[]);
+
+        public addRules(rules: AtomizerRule[]): void;
+        public findClassNames(src: string): string[];
+        public getConfig: (
+            classNames: string[],
+            config: AtomizerConfig
+        ) => AtomizerConfig;
+        public getCss(config: AtomizerConfig, options?: CSSOptions): string;
+        public getSyntax(isSimple?: boolean): RegExp;
+        public parseConfig(config: AtomizerConfig, options?: CSSOptions): any;
+        public sortCSS(classNames: string[]): string[];
+
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.7.0",
   "description": "A tool for creating Atomic CSS, a collection of single purpose styling units for maximum reuse",
   "main": "./src/atomizer.js",
+  "typings": "./index.d.ts",
   "contributors": [
     {
       "name": "Renato Iwashima",


### PR DESCRIPTION
This PR adds typescript types for anyone using `atomizer` in a typescript project.

We could certainly lock down some of the methods to be private, but I don't see any harm.