### PR TITLE
fix: recognize unquoted single attr class names

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -63,7 +63,7 @@ function flatten(obj) {
 
 // regular grammar to match valid atomic classes
 var GRAMMAR = {
-    'BOUNDARY'      : '(?:^|\\s|"|\'|\`|\{|\})',
+    'BOUNDARY'      : '(?:^|\\s|=|"|\'|\`|\{|\})',
     'PARENT'        : '[a-zA-Z][-_a-zA-Z0-9]+?',
     'PARENT_SEP'    : '[>_+~]',
     // all characters allowed to be a prop

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -69,6 +69,12 @@ describe('Atomizer()', function () {
           var expected = ['Pos(r)', 'Ov(h)', 'H(0)'];
           expect(result).to.deep.equal(expected);
         });
+        it('able to find classnames when unquoted', function () {
+            var atomizer = new Atomizer();
+            var result = atomizer.findClassNames('<div class=D(n)/>');
+            var expected = ['D(n)'];
+            expect(result).to.deep.equal(expected);
+        })
     });
     describe('addRules()', function () {
         it('throws if a rule with a different definition already exists', function () {


### PR DESCRIPTION
@src-code This PR adds support for unquoted attributes which is technically allowed per the spec. Currently `<div class=D(n)/>` is not found even though it's legal - though odd.

>Attributes are placed inside the start tag, and consist of a name and a value, separated by an "=" character. The attribute value can remain unquoted if it doesn't contain ASCII whitespace or any of " ' ` = < or >. Otherwise, it has to be quoted using either single or double quotes. The value, along with the "=" character, can be omitted altogether if the value is the empty string.

https://html.spec.whatwg.org/#restrictions-on-content-models-and-on-attribute-values

The motivation for this change in marko 4.19.9 https://github.com/marko-js/marko/pull/1535 which drops quotes on single attributes (ie no whitespace) causing some of our compiled templates to be parsed incorrectly.