### PR TITLE
fix: false positives

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -63,7 +63,7 @@ function flatten(obj) {
 
 // regular grammar to match valid atomic classes
 var GRAMMAR = {
-    'BOUNDARY'      : '(?:^|\\s|=|"|\'|\`|\{|\})',
+    'BOUNDARY'      : '(?:^|\\s|class=|"|\'|\`|\{|\})',
     'PARENT'        : '[a-zA-Z][-_a-zA-Z0-9]+?',
     'PARENT_SEP'    : '[>_+~]',
     // all characters allowed to be a prop

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -74,7 +74,13 @@ describe('Atomizer()', function () {
             var result = atomizer.findClassNames('<div class=D(n)/>');
             var expected = ['D(n)'];
             expect(result).to.deep.equal(expected);
-        })
+        });
+        it('able not match = unless preceded by class', function () {
+            var atomizer = new Atomizer();
+            var result = atomizer.findClassNames('foo=D(b);class=D(n)');
+            var expected = ['D(n)'];
+            expect(result).to.deep.equal(expected);
+        });
     });
     describe('addRules()', function () {
         it('throws if a rule with a different definition already exists', function () {


### PR DESCRIPTION
@src-code Reduce false positives by _only_ allowing `=` with `class=` otherwise we would match minified js such as `foo=D(b)`