### PR TITLE
Add support for focus-visible

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -17,6 +17,7 @@ var PSEUDO_CLASSES = {
     ':fullscreen':        ':fs',
     ':focus':             ':f',
     ':focus-within':      ':fw',
+    ':focus-visible':     ':fv',
     ':hover':             ':h',
     ':indeterminate':     ':ind',
     ':in-range':          ':ir',


### PR DESCRIPTION
> The :focus-visible pseudo-class applies while an element matches the :focus pseudo-class and the UA (User Agent) determines via heuristics that the focus should be made evident on the element. (Many browsers show a “focus ring” by default in this case.)
> 
> This selector is useful to provide a different focus indicator based on the user’s input modality (mouse vs. keyboard).
> 
> Note that Firefox supports similar functionality through an older, prefixed pseudo-class — :-moz-focusring.

https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible

Chrome 86 just released with the support.