### PR TITLE
Add support for custom value substitution

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -305,30 +305,28 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                     // now check if named value was passed in the config
                     else {
                         propAndValue = [match.atomicSelector, '(', matchVal.named, ')'].join('');
+                        var name;
 
                         // no custom, warn it
                         if (!config.custom) {
                             warnings.push(propAndValue);
-                            // set to null so we don't write it to the css
-                            value = null;
                         }
                         // as prop + value
                         else if (config.custom.hasOwnProperty(propAndValue)) {
-                            value = config.custom[propAndValue];
+                            name = propAndValue;
                         }
                         // as value
                         else if (config.custom.hasOwnProperty(matchVal.named)) {
-                            value = config.custom[matchVal.named];
+                            name = matchVal.named;
                         }
                         // we have custom but we could not find the named class name there
                         else {
                             warnings.push(propAndValue);
-                            // set to null so we don't write it to the css
-                            value = null;
                         }
+                        value = utils.getCustomValue(config, name);
                     }
                 }
-                return utils.replaceCustomValueTokens(config, value);
+                return value;
             });
         }
 

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -328,7 +328,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                         }
                     }
                 }
-                return value;
+                return utils.replaceCustomValueTokens(config, value);
             });
         }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -79,7 +79,7 @@ utils.getCustomValue = function (config/*:Config*/, currentName/*:string*/, name
     // Expectation is that 20 should be a more than reasonble depth
     // to assume something is wrong
     if (nameStack.length > 20) {
-        throw new Error('Infinite loop detected while substituting custom value tokens. Make sure your custom values don\'t contain tokens that reference one another. Aborting. Custom value trace: ' + nameStack.join(' > '));
+        throw new Error('Depth limit reached while substituting custom value tokens. Ensure your custom values don\'t contain tokens that reference one another, leading to an infinite loop.\n\nCustom value trace: ' + nameStack.join(' > '));
     }
 
     return value.replace(customValueTokenRegex, (token, name) => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -53,20 +53,37 @@ utils.repeatString = function (pattern/*:string*/, count/*:integer*/) {
     return result + pattern;
 };
 
-// replaces custom value tokens found in a string
-utils.replaceCustomValueTokens = function (config/*:Config*/, value/*:string*/, depth/*:integer*/)/*:string*/ {
-    depth = depth || 1;
-    if (typeof value !== 'string' || value.indexOf('#{') === -1 || !config || !config.custom) {
+// Performs a lookup of custom value tokens, recursively replacing
+//  any custom value tokens found within each custom value
+utils.getCustomValue = function (config/*:Config*/, currentName/*:string*/, nameStack/*:string[]*/)/*:string*/ {
+    nameStack = nameStack || [];
+
+    if (typeof currentName !== 'string' || !config || !config.custom) {
+        return null;
+    }
+
+    // If not found, return null, which will prevent the rule
+    // from being written to CSS
+    value = config.custom[currentName] || null;
+
+    // Short circuit if value isn't a string, or doesn't contain
+    // any tokens that need to be replaced
+    if (typeof value !== 'string' || value.indexOf('#{') === -1) {
         return value;
     }
-    // Don't allow for infinite loops!
-    if (depth > 10) {
-        throw new Error('Infinite loop detected while substituting custom value tokens. Make sure your custom values don\'t contain tokens that reference one another. Aborting.');
+
+    // Add this custom value name to our breadcrumb trail
+    nameStack.push(currentName);
+
+    // Limit the depth of recursion to help avoid infinite loops
+    // Expectation is that 20 should be a more than reasonble depth
+    // to assume something is wrong
+    if (nameStack.length > 20) {
+        throw new Error('Infinite loop detected while substituting custom value tokens. Make sure your custom values don\'t contain tokens that reference one another. Aborting. Custom value trace: ' + nameStack.join(' > '));
     }
 
     return value.replace(customValueTokenRegex, (token, name) => {
-        var value = config.custom[name] || '';
-        return this.replaceCustomValueTokens(config, value, ++depth);
+        return this.getCustomValue(config, name, nameStack);
     });
 };
 

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -479,7 +479,7 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
-        it ('returns css if coliding helper and atomic rule is used at the same time', function () {
+        it ('returns css if colliding helper and atomic rule is used at the same time', function () {
             var atomizer = new Atomizer();
             var config = {
                 custom: {
@@ -763,6 +763,56 @@ describe('Atomizer()', function () {
             ].join('\n');
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
+        });
+        it('returns expected css value declared in custom with variable substitution', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                custom: {
+                    '$main-color': '#000000',
+                    'brand-color': '#400090',
+                    'my-gradient': 'linear-gradient(to bottom, #{$main-color}, #{brand-color})'
+                },
+                classNames: ['Bg(my-gradient)']
+            };
+            var expected = [
+                '.Bg\\(my-gradient\\) {',
+                '  background: linear-gradient(to bottom, #000000, #400090);',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+        it('returns expected css value declared in custom with nested variable substitution', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                custom: {
+                    'black': '#000000',
+                    '$main-color': '#{black}',
+                    'brand-color': '#400090',
+                    'my-gradient': 'linear-gradient(to bottom, #{$main-color}, #{brand-color})'
+                },
+                classNames: ['Bg(my-gradient)']
+            };
+            var expected = [
+                '.Bg\\(my-gradient\\) {',
+                '  background: linear-gradient(to bottom, #000000, #400090);',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+        it('avoids infinite loops in custom with nested variable substitution', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                custom: {
+                    'black': '#{$main-color}',
+                    '$main-color': '#{black}',
+                    'brand-color': '#400090',
+                    'my-gradient': 'linear-gradient(to bottom, #{$main-color}, #{brand-color})'
+                },
+                classNames: ['Bg(my-gradient)']
+            };
+            expect(function () { atomizer.getCss(config) }).to.throw();
         });
         it ('returns expected css value with breakpoints', function () {
             var atomizer = new Atomizer(null, [


### PR DESCRIPTION
Implements #377, with support for recursive substitutions (maximum depth of 10 substitutions to prevent infinite loops, at which point it throws.)  

cc @snyamathi @redonkulus @carriemorrison @renatoi @thierryk 