### PR TITLE
fix(391): don't mutate existing config in getConfig

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -122,8 +122,8 @@ Atomizer.prototype.findClassNames = function (src/*:string*/)/*:string[]*/ {
  *
  * getConfig(['Op(1)', 'D(n):h']);
  */
-Atomizer.prototype.getConfig = function (classNames/*:string[]*/, config/*:AtomizerConfig*/)/*:AtomizerConfig*/ {
-    config = config || { classNames: [] };
+Atomizer.prototype.getConfig = function (classNames/*:string[]*/, existingConfig/*:AtomizerConfig*/)/*:AtomizerConfig*/ {
+    const config = existingConfig && _.cloneDeep(existingConfig) || { classNames: [] };
     // merge classnames with config
     config.classNames = this.sortCSS(_.union(classNames || [], config.classNames));
     return config;

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -620,14 +620,14 @@ describe('Atomizer()', function () {
         });
 
         it ('returns expected css if media query specificity bump option has been passed', function () {
-            const atomizer = new Atomizer();
-            const config = {
+            var atomizer = new Atomizer();
+            var config = {
                 breakPoints: {
                     sm: '@media(min-width:400px)'
                 },
                 classNames: ['C(red)', 'C(red)--sm']
             };
-            const expected = [
+            var expected = [
                 '.C\\(red\\) {',
                 '  color: red;',
                 '}',
@@ -637,7 +637,7 @@ describe('Atomizer()', function () {
                 '  }',
                 '}\n'
             ].join('\n');
-            const result = atomizer.getCss(config, {bumpMQ: true});
+            var result = atomizer.getCss(config, {bumpMQ: true});
             expect(result).to.equal(expected);
         });
 

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -316,6 +316,23 @@ describe('Atomizer()', function () {
             const result = atomizer.getConfig();
             expect(result).to.deep.equal(expected);
         });
+        it ('should not mutate the argument passed into getConfig', function () {
+            const atomizer = new Atomizer();
+            const classNames = ['P(55px)', 'D(b)'];
+            const existingConfig = {
+                custom: {
+                    heading: '80px'
+                },
+                classNames: ['M(10px)', 'D(ib)']
+            };
+            atomizer.getConfig(classNames, existingConfig);
+            expect(existingConfig).to.deep.equal({
+                custom: {
+                    heading: '80px'
+                },
+                classNames: ['M(10px)', 'D(ib)']
+            });
+        });
     });
     describe('getCss()', function () {
         it ('returns expected css for custom classes with break points', function () {
@@ -603,14 +620,14 @@ describe('Atomizer()', function () {
         });
 
         it ('returns expected css if media query specificity bump option has been passed', function () {
-            var atomizer = new Atomizer();
-            var config = {
+            const atomizer = new Atomizer();
+            const config = {
                 breakPoints: {
                     sm: '@media(min-width:400px)'
                 },
                 classNames: ['C(red)', 'C(red)--sm']
             };
-            var expected = [
+            const expected = [
                 '.C\\(red\\) {',
                 '  color: red;',
                 '}',
@@ -620,7 +637,7 @@ describe('Atomizer()', function () {
                 '  }',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(config, {bumpMQ: true});
+            const result = atomizer.getCss(config, {bumpMQ: true});
             expect(result).to.equal(expected);
         });
 


### PR DESCRIPTION
Fixes: https://github.com/acss-io/atomizer/issues/391

This PR prevents the mutation of the config which is passed into getConfig.

The documentation shows the declaration of `finalConfig` as a separate variable from `defaultConfig` so I don't believe this mutation is an intentional part of the API, just an accidental oversight. However, this could potentially cause issues for someone who was (incorrectly / unknowingly) depending on this side effect.

```js
// Generate Atomizer configuration from an array of Atomic classnames
var finalConfig = atomizer.getConfig(foundClasses, defaultConfig);
```
> https://github.com/acss-io/atomizer#api