### PR TITLE
feat: support css variables

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -291,6 +291,9 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                         value = matchVal.hex;
                     }
                 }
+                if (matchVal.cssVariable) {
+                    value = `var(${matchVal.cssVariable})`;
+                }
                 if (matchVal.named) {
                     // first check if 'inh' is the value
                     if (matchVal.named === 'inh') {

--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -80,6 +80,7 @@ const GRAMMAR = {
     'IMPORTANT'     : '!',
     // https://regex101.com/r/mM2vT9/8
     'NAMED'         : '([\\w$]+(?:(?:-(?!\\-))?\\w*)*)',
+    'CSS_VARIABLE'  : '(--(?:(?:-(?!\\-))?\\w*)*)',
     'BREAKPOINT'    : '--(?<breakPoint>[a-zA-Z0-9]+)',
     'PSEUDO_CLASS'  : `(?:${  flatten(PSEUDO_CLASSES).join('|')  })(?![a-z])`,
     'PSEUDO_ELEMENT': `(?:${  flatten(PSEUDO_ELEMENTS).join('|')  })(?![a-z])`,
@@ -140,6 +141,10 @@ const VALUE_SYNTAXE = XRegExp([
     '(?<unit>',
         GRAMMAR.UNIT,
     ')?',
+    '|',
+    '(?<cssVariable>',
+        GRAMMAR.CSS_VARIABLE,
+    ')',
     '|',
     '(?<named>',
         GRAMMAR.NAMED,

--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -80,7 +80,7 @@ const GRAMMAR = {
     'IMPORTANT'     : '!',
     // https://regex101.com/r/mM2vT9/8
     'NAMED'         : '([\\w$]+(?:(?:-(?!\\-))?\\w*)*)',
-    'CSS_VARIABLE'  : '(--(?:(?:-(?!\\-))?\\w*)*)',
+    'CSS_VARIABLE'  : '(--[\\w-]+)',
     'BREAKPOINT'    : '--(?<breakPoint>[a-zA-Z0-9]+)',
     'PSEUDO_CLASS'  : `(?:${  flatten(PSEUDO_CLASSES).join('|')  })(?![a-z])`,
     'PSEUDO_ELEMENT': `(?:${  flatten(PSEUDO_ELEMENTS).join('|')  })(?![a-z])`,

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -1120,7 +1120,7 @@ describe('Atomizer()', function () {
             const result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
-        it ('has do not match bad input', function () {
+        it ('should not match bad input', function () {
             const atomizer = new Atomizer();
             const config = {
                 classNames: [

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -1074,13 +1074,26 @@ describe('Atomizer()', function () {
         it ('has basic suppport for css variables', function () {
             const atomizer = new Atomizer();
             const config = {
+                breakPoints: {
+                    sm: '@media screen and (min-width:700px)'
+                },
                 classNames: [
-                    'C(--brand-color)'
+                    'C(--brand-color)',
+                    'Fz(--font-size)',
+                    'Fz(--small-font-size)--sm'
                 ]
             };
             const expected = [
                 '.C\\(--brand-color\\) {',
                 '  color: var(--brand-color);',
+                '}',
+                '.Fz\\(--font-size\\) {',
+                '  font-size: var(--font-size);',
+                '}',
+                '@media screen and (min-width:700px) {',
+                '  .Fz\\(--small-font-size\\)--sm {',
+                '    font-size: var(--small-font-size);',
+                '  }',
                 '}\n'
             ].join('\n');
             const result = atomizer.getCss(config);

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -1071,6 +1071,21 @@ describe('Atomizer()', function () {
             const result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('has basic suppport for css variables', function () {
+            const atomizer = new Atomizer();
+            const config = {
+                classNames: [
+                    'C(--brand-color)'
+                ]
+            };
+            const expected = [
+                '.C\\(--brand-color\\) {',
+                '  color: var(--brand-color);',
+                '}\n'
+            ].join('\n');
+            const result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
     });
     // -------------------------------------------------------
     // escapeSelector()

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -1071,6 +1071,8 @@ describe('Atomizer()', function () {
             const result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+    });
+    describe('css variables', function () {
         it ('has basic suppport for css variables', function () {
             const atomizer = new Atomizer();
             const config = {
@@ -1078,12 +1080,16 @@ describe('Atomizer()', function () {
                     sm: '@media screen and (min-width:700px)'
                 },
                 classNames: [
+                    'C(--foo)',
                     'C(--brand-color)',
                     'Fz(--font-size)',
                     'Fz(--small-font-size)--sm'
                 ]
             };
             const expected = [
+                '.C\\(--foo\\) {',
+                '  color: var(--foo);',
+                '}',
                 '.C\\(--brand-color\\) {',
                 '  color: var(--brand-color);',
                 '}',
@@ -1096,6 +1102,36 @@ describe('Atomizer()', function () {
                 '  }',
                 '}\n'
             ].join('\n');
+            const result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+        it('should match multiple css variables', function () {
+            const atomizer = new Atomizer();
+            const config = {
+                classNames: [
+                    'Bdsp(--foo,--bar)'
+                ]
+            };
+            const expected = [
+                '.Bdsp\\(--foo\\,--bar\\) {',
+                '  border-spacing: var(--foo) var(--bar);',
+                '}\n'
+            ].join('\n');
+            const result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+        it ('has do not match bad input', function () {
+            const atomizer = new Atomizer();
+            const config = {
+                classNames: [
+                    'C(--)',
+                    'C(-- foo)',
+                    'C(--$)',
+                    'C(--)',
+                    '--bar'
+                ]
+            };
+            const expected = '';
             const result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -1127,7 +1127,6 @@ describe('Atomizer()', function () {
                     'C(--)',
                     'C(-- foo)',
                     'C(--$)',
-                    'C(--)',
                     '--bar'
                 ]
             };


### PR DESCRIPTION
@redonkulus @renatoi @src-code This PR (attempts to) add support for [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).

This is merely basic support, echoing the token if it starts with a double dash. There is no requirement that the variables be defined in the config since it's likely that the variables defined by some shared CSS outside of atomizer.

There are other features that I _wanted_ to accomplish, but was not able to. The only marginally important one is fallback, and even that can be done with postcss using [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties).

**I'm also not sure how many folks still cater to IE11 and if we want to spend the time creating features in this repo to support IE11.**

## Fallback

Ideally we could (optionally) provide fallbacks for browsers that cannot understand css variables

```css
.C\(--brand-color\) {
  color: #400090;
  color: var(--brand-color);
}
```

The main impediment to this, however, is that all the way down to [writeBlockToCSS](https://github.com/acss-io/atomizer/blob/master/src/lib/jss.js#L167), there is an assumption that there is only one value for a given property.

Passing fallback values around becomes a bit cumbersome - though hopefully someone else can take a stab at this.

## Definitions

It would be nice to (optionally) create the variable definitions created by Atomizer itself.

```css
:root {
  --brand-color: #400090;
}
```

## Re-Define Media Queries

If Atomizer does create the definitions, it may be nice to have the definitions change depending on media queries such as

```css
@media (prefers-color-scheme: dark) {
  :root {
    --background-color: #000;
    --text-color: #fff;
  }
}
```

## Custom Definition Selectors

In the above definitions, we may (optionally) want `:root` to be some other selector. 
