### PR TITLE
Removing `--ie` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Usage: atomizer [options] [path]
     -w, --watch=[target]                rebuilds when changes are detected in the file, directory, or glob (argument may be passed multiple times and is parsed for Atomic CSS classes)
 
     --rtl                               swaps `start` and `end` keyword replacements with `right` and `left`.
-    --ie                                adds old IE hacks to the output.
     --exclude=[pattern]                 pattern to exclude file to be scanned
     --bump-mq                           increases specificity of media queries a small amount
     --verbose                           show additional log info (warnings).

--- a/bin/atomizer
+++ b/bin/atomizer
@@ -203,11 +203,6 @@ if (typeof program.helpersNamespace !== 'undefined') {
     options.helpersNamespace = program.helpersNamespace;
 }
 
-// Options: IE
-if (typeof program.ie !== 'undefined') {
-    options.ie = true;
-}
-
 if (program.watch.length) {
     var buildTriggerState = { files: {} };
     var watcher = chokidar.watch(program.watch)

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -349,22 +349,6 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
         for (const prop in treeo.declarations) {
             if (values) {
                 values.forEach((value, index) => {
-                    // plug IE hacks for know properties
-                    if (options.ie) {
-                        // block formatting context on old IE
-                        /* istanbul ignore else  */
-                        if ((prop === 'display' && value === 'inline-block') || (prop === 'overflow' && value !== 'visible')) {
-                            treeo.declarations.zoom = 1;
-                        }
-                        /* istanbul ignore else  */
-                        if (prop === 'display' && value === 'inline-block') {
-                            treeo.declarations['*display'] = 'inline';
-                        }
-                        /* istanbul ignore else  */
-                        if (prop === 'opacity') {
-                            treeo.declarations.filter = `alpha(opacity=${  parseFloat(value, 10) * 100  })`;
-                        }
-                    }
                     if (value !== null && treeo.declarations) {
                         // value could be an object for custom classes with breakPoints
                         // e.g.
@@ -468,8 +452,7 @@ Atomizer.prototype.getCss = function (config/*:AtomizerConfig*/, options/*:CSSOp
         banner: '',
         bumpMQ: false,
         namespace: null,
-        rtl: false,
-        ie: false
+        rtl: false
     }, options);
 
     // validate config.breakPoints

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -348,22 +348,5 @@ module.exports = [
             'bottom': 0,
             'left': 0
         }
-    },
-    /**
-    ==================================================================
-    Zoom
-    hack for oldIE to create a "block-formatting context"
-    ==================================================================
-    */
-    {
-        'type': 'helper',
-        'name': 'Zoom',
-        'description': "Gives a box 'layout' in old versions of Internet Explorer",
-        'link': 'https://acss.io/guides/helper-classes.html#-zoom-',
-        'matcher': 'Zoom',
-        'noParams': true,
-        'styles': {
-            'zoom': '1'
-        }
     }
 ];

--- a/src/lib/jss.js
+++ b/src/lib/jss.js
@@ -79,13 +79,7 @@ JSS.combineSelectors = function (extracted/*:Extracted*/)/*:Extracted*/ {
     for (const block in extracted) {
         extracts = extracted[block];
         for (let i = 0, l = extracts.length; i < l; i += 1) {
-            // If this selector has an escaped colon, we can't safely combine it
-            // with another selector since it will break in IE < 8
-            if (extracts[i].selector && extracts[i].selector.indexOf('\:') > -1) { continue; }
             for(let j = i + 1; j < l; j += 1) {
-                // If this selector has an escaped colon, we can't safely combine it
-                // with another selector since it will break in IE < 8
-                if (extracts[j].selector && extracts[j].selector.indexOf('\:') > -1) { continue; }
                 // combine if prop and value match
                 if(extracts[i].prop === extracts[j].prop && extracts[i].value === extracts[j].value) {
                     if (extracts[j].selector) {

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -547,10 +547,7 @@ describe('Atomizer()', function () {
                 '.C\\(red\\) {',
                 '  color: red;',
                 '}',
-                '.C\\(\\#333\\) {',
-                '  color: #333;',
-                '}',
-                '.C\\(\\#333\\)\\:li:link {',
+                '.C\\(\\#333\\), .C\\(\\#333\\)\\:li:link {',
                 '  color: #333;',
                 '}',
                 '.Cnt\\(cq\\)\\:h\\:\\:b:hover::before {',
@@ -580,13 +577,7 @@ describe('Atomizer()', function () {
                 '.End\\(0\\) {',
                 '  right: 0;',
                 '}',
-                '.test:hover > .test\\:h\\>Op\\(1\\)\\:h:hover {',
-                '  opacity: 1;',
-                '}',
-                '.test:hover .test\\:h_Op\\(1\\)\\:h:hover {',
-                '  opacity: 1;',
-                '}',
-                '.Op\\(1\\) {',
+                '.test:hover > .test\\:h\\>Op\\(1\\)\\:h:hover, .test:hover .test\\:h_Op\\(1\\)\\:h:hover, .Op\\(1\\) {',
                 '  opacity: 1;',
                 '}',
                 '.Op\\(1\\)\\! {',
@@ -641,37 +632,6 @@ describe('Atomizer()', function () {
             expect(result).to.equal(expected);
         });
 
-        it ('returns expected css if IE option has been passed', function () {
-            // set rules here so if helper change, we don't fail the test
-            const atomizer = new Atomizer();
-            const config = {
-                classNames: ['Op(.33)', 'D(ib)', 'Ov(h)', 'Ov(s)', 'Ov(a)']
-            };
-            const expected = [
-                '.D\\(ib\\) {',
-                '  display: inline-block;',
-                '  *display: inline;',
-                '}',
-                '.D\\(ib\\), .Ov\\(h\\), .Ov\\(s\\), .Ov\\(a\\) {',
-                '  zoom: 1;',
-                '}',
-                '.Op\\(\\.33\\) {',
-                '  opacity: .33;',
-                '  filter: alpha(opacity=33);',
-                '}',
-                '.Ov\\(h\\) {',
-                '  overflow: hidden;',
-                '}',
-                '.Ov\\(s\\) {',
-                '  overflow: scroll;',
-                '}',
-                '.Ov\\(a\\) {',
-                '  overflow: auto;',
-                '}\n'
-            ].join('\n');
-            const result = atomizer.getCss(config, {ie: true});
-            expect(result).to.equal(expected);
-        });
         it ('returns expected css of a helper class', function () {
             // set rules here so if helper change, we don't fail the test
             const atomizer = new Atomizer(null, [


### PR DESCRIPTION
This is a suggestion for what it would take to remove `--ie` as an option, so IE < 8 hacks won't be employed.