### PR TITLE
feat: add more global values

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -319,10 +319,11 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                         else {
                             warnings.push(propAndValue);
                         }
-                        value = utils.getCustomValue(config, name);
 
-                        // use global values if no custom value was found
-                        if (!value) {
+                        if (name) {
+                            value = utils.getCustomValue(config, name);
+                        } else {
+                            // use global values if no custom value was found
                             switch (matchVal.groups.named) {
                                 case 'inh':
                                     value = 'inherit';

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -14,6 +14,14 @@ const XRegExp = require('xregexp');
 
 const RULES = require('./rules.js').concat(require('./helpers.js'));
 
+const GLOBAL_VALUES = {
+    inh: 'inherit',
+    ini: 'initial',
+    rv: 'revert',
+    rvl: 'revert-layer',
+    un: 'unset'
+};
+
 /**
  * constructor
  */
@@ -313,28 +321,9 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                                 name = matchVal.groups.named;
                             }
                         }
-                        value = utils.getCustomValue(config, name);
 
-                        if (!value) {
-                            // use global values if no custom value was found
-                            switch (matchVal.groups.named) {
-                                case 'inh':
-                                    value = 'inherit';
-                                    break;
-                                case 'ini':
-                                    value = 'initial';
-                                    break;
-                                case 'rv':
-                                    value = 'revert';
-                                    break;
-                                case 'rvl':
-                                    value = 'revert-layer';
-                                    break;
-                                case 'un':
-                                    value = 'unset';
-                                    break;
-                            }
-                        }
+                        // use global values if no custom value was found
+                        value = utils.getCustomValue(config, name) || GLOBAL_VALUES[matchVal.groups.named] || null;
 
                         if (!value) {
                             warnings.push(propAndValue);

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -295,9 +295,21 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                     value = `var(${matchVal.groups.cssVariable})`;
                 }
                 if (matchVal.groups.named) {
-                    // first check if 'inh' is the value
+                    // add global values first
                     if (matchVal.groups.named === 'inh') {
                         value = 'inherit';
+                    }
+                    else if (matchVal.groups.named === 'ini') {
+                        value = 'initial';
+                    }
+                    else if (matchVal.groups.named === 'rv') {
+                        value = 'revert';
+                    }
+                    else if (matchVal.groups.named === 'rvl') {
+                        value = 'revert-layer';
+                    }
+                    else if (matchVal.groups.named === 'un') {
+                        value = 'unset';
                     }
                     // check if the named value matches any of the values
                     // registered in arguments.

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -245,8 +245,6 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
             // parse them and return a valid value
             values = values.split(',').map(function (value, index) {
                 const matchVal = Grammar.matchValue(value);
-                let propAndValue;
-
                 if (!matchVal) {
                     // In cases like: End(-), matchVal will be null.
                     return null;
@@ -295,30 +293,14 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                     value = `var(${matchVal.groups.cssVariable})`;
                 }
                 if (matchVal.groups.named) {
-                    // add global values first
-                    if (matchVal.groups.named === 'inh') {
-                        value = 'inherit';
-                    }
-                    else if (matchVal.groups.named === 'ini') {
-                        value = 'initial';
-                    }
-                    else if (matchVal.groups.named === 'rv') {
-                        value = 'revert';
-                    }
-                    else if (matchVal.groups.named === 'rvl') {
-                        value = 'revert-layer';
-                    }
-                    else if (matchVal.groups.named === 'un') {
-                        value = 'unset';
-                    }
                     // check if the named value matches any of the values
                     // registered in arguments.
-                    else if (rule.arguments && index < rule.arguments.length && Object.keys(rule.arguments[index]).indexOf(matchVal.groups.named) >= 0) {
+                    if (rule.arguments && index < rule.arguments.length && Object.keys(rule.arguments[index]).indexOf(matchVal.groups.named) >= 0) {
                         value = rule.arguments[index][matchVal.groups.named];
                     }
                     // now check if named value was passed in the config
                     else {
-                        propAndValue = [match.groups.atomicSelector, '(', matchVal.groups.named, ')'].join('');
+                        const propAndValue = [match.groups.atomicSelector, '(', matchVal.groups.named, ')'].join('');
                         let name;
 
                         // no custom, warn it
@@ -338,6 +320,27 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                             warnings.push(propAndValue);
                         }
                         value = utils.getCustomValue(config, name);
+
+                        // use global values if no custom value was found
+                        if (!value) {
+                            switch (matchVal.groups.named) {
+                                case 'inh':
+                                    value = 'inherit';
+                                    break;
+                                case 'ini':
+                                    value = 'initial';
+                                    break;
+                                case 'rv':
+                                    value = 'revert';
+                                    break;
+                                case 'rvl':
+                                    value = 'revert-layer';
+                                    break;
+                                case 'un':
+                                    value = 'unset';
+                                    break;
+                            }
+                        }
                     }
                 }
                 return value;

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -312,16 +312,10 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                             else if (Object.prototype.hasOwnProperty.call(config.custom, matchVal.groups.named)) {
                                 name = matchVal.groups.named;
                             }
-                            else {
-                                // we have custom but we could not find the named class name there
-                                warnings.push(propAndValue);
-                            }
                         }
                         value = utils.getCustomValue(config, name);
 
                         if (!value) {
-                            warnings.push(propAndValue);
-
                             // use global values if no custom value was found
                             switch (matchVal.groups.named) {
                                 case 'inh':
@@ -340,6 +334,10 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                                     value = 'unset';
                                     break;
                             }
+                        }
+
+                        if (!value) {
+                            warnings.push(propAndValue);
                         }
                     }
                 }

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -303,26 +303,25 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                         const propAndValue = [match.groups.atomicSelector, '(', matchVal.groups.named, ')'].join('');
                         let name;
 
-                        // no custom, warn it
-                        if (!config.custom) {
-                            warnings.push(propAndValue);
+                        if (config.custom) {
+                            // as prop + value
+                            if (Object.prototype.hasOwnProperty.call(config.custom, propAndValue)) {
+                                name = propAndValue;
+                            }
+                            // as value
+                            else if (Object.prototype.hasOwnProperty.call(config.custom, matchVal.groups.named)) {
+                                name = matchVal.groups.named;
+                            }
+                            else {
+                                // we have custom but we could not find the named class name there
+                                warnings.push(propAndValue);
+                            }
                         }
-                        // as prop + value
-                        else if (Object.prototype.hasOwnProperty.call(config.custom, propAndValue)) {
-                            name = propAndValue;
-                        }
-                        // as value
-                        else if (Object.prototype.hasOwnProperty.call(config.custom, matchVal.groups.named)) {
-                            name = matchVal.groups.named;
-                        }
-                        // we have custom but we could not find the named class name there
-                        else {
-                            warnings.push(propAndValue);
-                        }
+                        value = utils.getCustomValue(config, name);
 
-                        if (name) {
-                            value = utils.getCustomValue(config, name);
-                        } else {
+                        if (!value) {
+                            warnings.push(propAndValue);
+
                             // use global values if no custom value was found
                             switch (matchVal.groups.named) {
                                 case 'inh':

--- a/src/rules.js
+++ b/src/rules.js
@@ -6,7 +6,12 @@
  * ----------------------------------------------------
  *
  * These are the main Atomic CSS rules.
- * By default, all rules accept "inh" ("inherit").
+ * By default, all rules accept:
+ *  - "inh" ("inherit")
+ *  - "ini" ("initial")
+ *  - "rv" ("revert")
+ *  - "rvl" ("revert-layer")
+ *  - "un" ("unset")
  *
  * Please submit a PR if you find any missing rule.
  *
@@ -200,13 +205,7 @@ module.exports = [
         'allowParamToValue': false,
         'styles': {
             'aspect-ratio': '$0'
-        },
-        'arguments': [{
-            'ini': 'initial',
-            'r': 'revert',
-            'rl': 'revert-layer',
-            'u': 'unset'
-        }]
+        }
     },
     /**
     ==================================================================
@@ -894,11 +893,7 @@ module.exports = [
             'mb': 'margin-box',
             'n': 'none',
             'pb': 'padding-box',
-            'ini': 'initial',
-            'r': 'revert',
-            'rl': 'revert-layer',
             'sb': 'stroke-box',
-            'u': 'unset',
             'vb': 'view-box'
         }]
     },
@@ -2032,7 +2027,6 @@ module.exports = [
             'a': 'auto',
             'fa': 'fill-available',
             'fc': 'fit-content',
-            'ini': 'initial',
             'maxc': 'max-content',
             'minc': 'min-content'
         }]

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -619,6 +619,32 @@ describe('Atomizer()', function () {
             expect(result).to.equal(expected);
         });
 
+        it ('returns css for all global values', function () {
+            const atomizer = new Atomizer();
+            const config = {
+                classNames: ['Bd(inh)', 'Bd(ini)', 'Bd(rv)', 'Bd(rvl)', 'Bd(un)']
+            };
+            const expected = [
+                '.Bd\\(inh\\) {',
+                '  border: inherit;',
+                '}',
+                '.Bd\\(ini\\) {',
+                '  border: initial;',
+                '}',
+                '.Bd\\(rv\\) {',
+                '  border: revert;',
+                '}',
+                '.Bd\\(rvl\\) {',
+                '  border: revert-layer;',
+                '}',
+                '.Bd\\(un\\) {',
+                '  border: unset;',
+                '}\n'
+            ].join('\n');
+            const result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+
         it ('returns expected css if media query specificity bump option has been passed', function () {
             const atomizer = new Atomizer();
             const config = {


### PR DESCRIPTION
We currently already support `inherit`, this PR adds the remaining global values (`initial`, `revert`, `revert-layer`, `unset`).

I cleaned up the rules that were using these already.