### PR TITLE
feat: add missing pseudo elements

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -43,11 +43,16 @@ const PSEUDO_CLASSES = {
 };
 
 const PSEUDO_ELEMENTS = {
-    '::before':         '::b',
-    '::after':          '::a',
-    '::first-letter':   '::fl',
-    '::first-line':     '::fli',
-    '::placeholder':    '::ph'
+    '::after':                  '::a',
+    '::before':                 '::b',
+    '::backdrop':               '::bd',
+    '::cue':                    '::c',
+    '::file-selector-button':   '::fsb',
+    '::first-letter':           '::fl',
+    '::first-line':             '::fli',
+    '::marker':                 '::m',
+    '::placeholder':            '::ph',
+    '::selection':              '::s'
 };
 
 const PSEUDOS = Object.assign({}, PSEUDO_CLASSES, PSEUDO_ELEMENTS);


### PR DESCRIPTION
Add missing `pseudo-elements` from the MDN page. I ignored experimental elements until they are  generally available.

@src-code There are two pseudo elements that I'm not sure would work with the current grammar rules:

- `::part()` - https://developer.mozilla.org/en-US/docs/Web/CSS/::part
- `::slotted()` - https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted

Both of these have parentheses and I'm not sure if atomizer supports this syntax at the moment. 