### PR TITLE
Fixes acss-io/atomizer#314 add missing second rule

### DIFF
--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -371,6 +371,8 @@ module.exports = [
         },
         'arguments': [{
             'i': 'inherit'
+        }, {
+            'i': 'inherit'
         }]
     },
     /**


### PR DESCRIPTION
### Description

Fixes missing second named arg

### Motivation and Context

Bug

### How Has This Been Tested?
Tested on command line
```
Parsing file examples/html/sample-1.html for Atomic CSS classes

.Bdsp\(1px\,i\) {
  border-spacing: 1px inherit;
}
.foo .foo_Bdsp\(i\,1px\) {
  border-spacing: inherit 1px;
}
.H\(100\%\) {
  height: 100%;
}
.W\(500px\) {
  width: 500px;
}
```

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Fixes #314 

Review the following points, and put an x in all the boxes that apply. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help!

- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/acss-io/atomizer/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.

---

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
