### PR TITLE
Add outline-offset rule

### DIFF
--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -2123,6 +2123,16 @@ module.exports = [
             'n': 'none'
         }]
     },
+    {
+        'type': 'pattern',
+        'name': 'Outline-offset',
+        'matcher': 'Oo',
+        'shorthand': true,
+        'allowParamToValue': true,
+        'styles': {
+            'outline-offset': '$0'
+        }
+    },
     /**
     ==================================================================
     OFFSETS


### PR DESCRIPTION
Add outline-offset rule
https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset

Outline-offset is a rule that is quite often used to stylize inputs and other elements.

I've tested it locally on my pet project.