### PR TITLE
feat(atomizer): updating the box alignment logic

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -18,5 +18,6 @@
 <h3 class="Fz(14px) BdT Fw(n) Pt(20px)">TUTORIALS</h3>
 <ul class="M(0) P(0)">
     <li class="{% if page.url == '/tutorials/grid-system.html' %}selected{% endif %}"><a class="D(b) Td(n):h Py(5px) Pos(r)" href="{{ "/tutorials/grid-system.html" | relative_url }}">Grid system</a></li>
+    <li class="{% if page.url == '/tutorials/alignment.html' %}selected{% endif %}"><a class="D(b) Td(n):h Py(5px) Pos(r)" href="{{ "/tutorials/alignment.html" | relative_url }}">Alignment</a></li>
     <li class="{% if page.url == '/tutorials/responsive-web-design.html' %}selected{% endif %}"><a class="D(b) Td(n):h Py(5px) Pos(r)" href="{{ "/tutorials/responsive-web-design.html" | relative_url }}">RWD</a></li>
 </ul>

--- a/docs/tutorials/alignment.md
+++ b/docs/tutorials/alignment.md
@@ -5,8 +5,9 @@ title: Box level alignment
 ---
 
 <p>These examples shows different ways relating to the alignment of boxes within their containers in the various CSS box layout models: block layout, table layout, flex layout</p>
-<p>**Note:** Grid is not currently supported</p>
-
+<p class="noteBox warning">
+    <b class="Fw(b)">NOTE:</b> Grid is not currently supported
+</p>
 {% include subhead.html tag="h3" title="<code>align-content</code> construct" %}
 
 <p>Aligns the contents of the box as a whole (as the alignment subject) within the box itself along the block/column/cross axis of the box. Following example shows <code>Ac(sb)</code>, <b class="Fw(b)">align-content: Space between</b></p>

--- a/docs/tutorials/alignment.md
+++ b/docs/tutorials/alignment.md
@@ -1,0 +1,105 @@
+---
+section: docs
+layout: docs
+title: Box level alignment
+---
+
+<p>These examples shows different ways relating to the alignment of boxes within their containers in the various CSS box layout models: block layout, table layout, flex layout</p>
+<p>**Note:** Grid is not currently supported</p>
+
+{% include subhead.html tag="h3" title="<code>align-content</code> construct" %}
+
+<p>Aligns the contents of the box as a whole (as the alignment subject) within the box itself along the block/column/cross axis of the box. Following example shows <code>Ac(sb)</code>, <b class="Fw(b)">align-content: Space between</b></p>
+
+{% highlight html %}
+<div class="D(f) Ac(sb) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Fxf(w)">
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+{% endhighlight %}
+
+<div class="D(f) Ac(sb) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Fxf(w)">
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="W(20px) H(20px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+
+{% include subhead.html tag="h3" title="<code>align-items</code> construct" %}
+
+<p>This property specifies the default <code>align-self</code> for <strong>all</strong> of the child boxes (including anonymous boxes) participating in this box’s formatting context.. Following example shows <code>Ai(c)</code>, <b class="Fw(b)">align-items: center</b></p>
+
+{% highlight html %}
+<div class="D(f) Ai(c) H(100px) Bgc(#add8e6) P(10px) Gp(10px) Mend(1rem)">
+    <div class="D(f) Ai(c) W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="D(f) Ai(c) W(20px) H(10px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="D(f) Ai(c) W(20px) H(40px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="D(f) Ai(c) W(20px) H(50px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+{% endhighlight %}
+
+<div class="D(f) Ai(c) H(100px) Bgc(#add8e6) P(10px) Gp(10px) Mend(1rem)">
+    <div class="D(f) Ai(c) W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="D(f) Ai(c) W(20px) H(10px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="D(f) Ai(c) W(20px) H(40px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="D(f) Ai(c) W(20px) H(50px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+
+{% include subhead.html tag="h3" title="<code>align-self</code> construct" %}
+
+<p>Aligns the box (as the alignment subject) within its containing block (as the alignment container) along the block/column/cross axis of the alignment container: the box’s outer edges are aligned within its alignment container as described by its alignment value. Following example shows <code>As(fs)</code>, <b class="Fw(b)">align-self: flex-start</b></p>
+
+{% highlight html %}
+<div class="D(f) Ai(c) H(100px) Bgc(#add8e6) P(10px) Gp(10px) Mend(1rem)">
+    <div class="As(fs) D(f) Ai(c) W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="D(f) Ai(c) W(20px) H(10px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="D(f) Ai(c) W(20px) H(40px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="D(f) Ai(c) W(20px) H(50px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+{% endhighlight %}
+
+<div class="D(f) Ai(c) H(100px) Bgc(#add8e6) P(10px) Gp(10px) Mend(1rem)">
+    <div class="As(fs) D(f) Ai(c) W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="D(f) Ai(c) W(20px) H(10px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="D(f) Ai(c) W(20px) H(40px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="D(f) Ai(c) W(20px) H(50px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+
+
+{% include subhead.html tag="h3" title="<code>justify-content</code> construct" %}
+
+<p>Aligns the contents of the box as a whole (as the alignment subject) within the box itself (as the alignment container) along the inline/row/main axis of the box. Following example shows <code>Jc(se)</code>, <b class="Fw(b)">justify-content: space-evenly</b></p>
+
+{% highlight html %}
+<div class="D(f) Jc(se) H(100px) Bgc(#add8e6) P(10px) Gp(10px) Mend(1rem)">
+    <div class="D(f) Ai(c) W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="D(f) Ai(c) W(20px) H(10px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="D(f) Ai(c) W(20px) H(40px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="D(f) Ai(c) W(20px) H(50px) P(1rem) Bgc(#ccc)">6</div>
+</div>
+{% endhighlight %}
+
+<div class="D(f) Jc(se) H(100px) Bgc(#add8e6) P(10px) Gp(10px) Mend(1rem)">
+    <div class="D(f) Ai(c) W(20px) H(20px) P(1rem) Bgc(#ccc)">1</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">2</div>
+    <div class="D(f) Ai(c) W(20px) H(10px) P(1rem) Bgc(#ccc)">3</div>
+    <div class="D(f) Ai(c) W(20px) H(40px) P(1rem) Bgc(#ccc)">4</div>
+    <div class="D(f) Ai(c) W(20px) H(30px) P(1rem) Bgc(#ccc)">5</div>
+    <div class="D(f) Ai(c) W(20px) H(50px) P(1rem) Bgc(#ccc)">6</div>
+</div>

--- a/examples/align.html
+++ b/examples/align.html
@@ -248,6 +248,95 @@
                     </div>
                 </div>
             </div>
+            <h2>Justify content</h2>
+            <P></P>
+            <div class="D(f) Fld(c)">
+                <div>
+                    <h3>Center</h3>
+                    <div class="D(f) Ai(fs) Jc(c) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Left</h3>
+                    <div class="D(f) Ai(fs) Jc(l) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Right</h3>
+                    <div class="D(f) Ai(fs) Jc(r) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Flex End</h3>
+                    <div class="D(f) Ai(fs) Jc(fe) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Flex Start</h3>
+                    <div class="D(f) Ai(fs) Jc(fs) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Space Around</h3>
+                    <div class="D(f) Ai(fs) Jc(sa) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Space between</h3>
+                    <div class="D(f) Ai(fs) Jc(sb) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Space evenly</h3>
+                    <div class="D(f) Ai(fs) Jc(se) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Stretch</h3>
+                    <p>Note: stretch is not supported by flexible boxes (flexbox).</p>
+                </div>
+            </div>
         </main>
 
         <!-- this is just to reload the page if you make any changes to the html -->

--- a/examples/align.html
+++ b/examples/align.html
@@ -225,6 +225,28 @@
                         <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
                     </div>
                 </div>
+                <div>
+                    <h3>Self End</h3>
+
+                    <div class="D(f) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(se)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Self Start</h3>
+
+                    <div class="D(f) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(ss)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
             </div>
         </main>
 

--- a/examples/align.html
+++ b/examples/align.html
@@ -1,0 +1,234 @@
+<!doctype html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+
+        <title>Atomizer: Grid</title>
+
+        <link rel="stylesheet" href="css/base.css">
+        <link rel="stylesheet" href="css/atomic.css">
+    </head>
+    <body>
+        <main>
+            <h1>Box level alignment</h1>
+
+            <p>This examples shows different ways relating to the alignment of boxes within their containers in the various CSS box layout models: block layout, table layout, flex layout</p>
+            <p>**Note:** Grid is not currently supported</p>
+
+            <h2>Align Content</h2>
+            <div class="D(f)">
+                <div>
+                    <h3>Center</h3>
+
+                    <div class="D(f) Ac(c) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Space around</h3>
+                    <div class="D(f) Ac(sa) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Space Between</h3>
+
+                    <div class="D(f) Ac(sb) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Space Evenly</h3>
+
+                    <div class="D(f) Ac(se) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Stretch</h3>
+
+                    <div class="D(f) Ac(st) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Flex End</h3>
+
+                    <div class="D(f) Ac(fe) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Flex Start</h3>
+
+                    <div class="D(f) Ac(fs) W(160px) H(300px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px) Fxf(w)">
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">1</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">2</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">4</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">5</div>
+                        <div class="W(20px) H(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+            </div>
+            <h2>Align Items</h2>
+            <div class="D(f) Fld(c)">
+                <div>
+                    <h3>Center</h3>
+
+                    <div class="D(f) Ai(c) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Stretch</h3>
+                    <div class="D(f) Ai(st) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Baseline</h3>
+
+                    <div class="D(f) Ai(b) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Flex End</h3>
+
+                    <div class="D(f) Ai(fe) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Flex Start</h3>
+
+                    <div class="D(f) Ai(fs) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+            </div>
+            <h2>Align Self</h2>
+            <P>1st items have self alignment</P>
+            <div class="D(f) Fld(c)">
+                <div>
+                    <h3>Center</h3>
+
+                    <div class="D(f) W(100%) Ai(fe) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(c)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Stretch</h3>
+                    <div class="D(f) W(100%) Ai(fe) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(st)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Baseline</h3>
+
+                    <div class="D(f) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mend(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(b)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3>Flex End</h3>
+
+                    <div class="D(f) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(fe)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+                <div>
+                    <h3>Flex Start</h3>
+
+                    <div class="D(f) W(100%) H(200px) Bgc(#add8e6) P(10px) Gp(10px) Mb(10px)">
+                        <div class="W(20px) P(2rem) Bgc(#ccc) As(fs)">1<br>2</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">3</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">4<br>5</div>
+                        <div class="W(20px) P(2rem) Bgc(#ccc)">6</div>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <!-- this is just to reload the page if you make any changes to the html -->
+        <script src="//localhost:35729/livereload.js"></script>
+    </body>
+</html>

--- a/examples/css/atomic.css
+++ b/examples/css/atomic.css
@@ -4,6 +4,12 @@
 .Bgbm\(di\) {
   background-blend-mode: difference;
 }
+.Bgbm\(n\) {
+  background-blend-mode: normal;
+}
+.foo .foo_Bgbm\(h\) {
+  background-blend-mode: hue;
+}
 .Bgc\(\#000\) {
   background-color: #000;
 }
@@ -68,6 +74,12 @@
 .My\(2rem\) {
   margin-top: 2rem;
   margin-bottom: 2rem;
+}
+.bar .bar_Mbm\(s\) {
+  mix-blend-mode: saturation;
+}
+.Mbm\(pl\) {
+  mix-blend-mode: plus-lighter;
 }
 .Mbm\(sc\) {
   mix-blend-mode: screen;

--- a/examples/css/atomic.css
+++ b/examples/css/atomic.css
@@ -109,6 +109,30 @@
 .Ac\(st\) {
   align-content: stretch;
 }
+.Jc\(c\) {
+  justify-content: center;
+}
+.Jc\(fe\) {
+  justify-content: flex-end;
+}
+.Jc\(fs\) {
+  justify-content: flex-start;
+}
+.Jc\(l\) {
+  justify-content: left;
+}
+.Jc\(r\) {
+  justify-content: right;
+}
+.Jc\(sa\) {
+  justify-content: space-around;
+}
+.Jc\(sb\) {
+  justify-content: space-between;
+}
+.Jc\(se\) {
+  justify-content: space-evenly;
+}
 .Fl\(start\) {
   float: left;
 }

--- a/examples/css/atomic.css
+++ b/examples/css/atomic.css
@@ -46,14 +46,80 @@
 .D\(n\)\! {
   display: none !important;
 }
+.As\(b\) {
+  align-self: baseline;
+}
+.As\(c\) {
+  align-self: center;
+}
+.As\(fe\) {
+  align-self: flex-end;
+}
+.As\(fs\) {
+  align-self: flex-start;
+}
+.As\(st\) {
+  align-self: stretch;
+}
+.Fld\(c\) {
+  flex-direction: column;
+}
+.Fxf\(w\) {
+  flex-flow: wrap;
+}
+.Ai\(b\) {
+  align-items: baseline;
+}
+.Ai\(c\) {
+  align-items: center;
+}
+.Ai\(fe\) {
+  align-items: flex-end;
+}
+.Ai\(fs\) {
+  align-items: flex-start;
+}
+.Ai\(st\) {
+  align-items: stretch;
+}
+.Ac\(c\) {
+  align-content: center;
+}
+.Ac\(fe\) {
+  align-content: flex-end;
+}
+.Ac\(fs\) {
+  align-content: flex-start;
+}
+.Ac\(sa\) {
+  align-content: space-around;
+}
+.Ac\(sb\) {
+  align-content: space-between;
+}
+.Ac\(se\) {
+  align-content: space-evenly;
+}
+.Ac\(st\) {
+  align-content: stretch;
+}
 .Fl\(start\) {
   float: left;
 }
 .Fz\(2rem\) {
   font-size: 2rem;
 }
+.Gp\(10px\) {
+  gap: 10px;
+}
 .H\(100\%\) {
   height: 100%;
+}
+.H\(200px\) {
+  height: 200px;
+}
+.H\(20px\) {
+  height: 20px;
 }
 .H\(300px\) {
   height: 300px;
@@ -75,6 +141,12 @@
   margin-top: 2rem;
   margin-bottom: 2rem;
 }
+.Mend\(10px\) {
+  margin-right: 10px;
+}
+.Mb\(10px\) {
+  margin-bottom: 10px;
+}
 .bar .bar_Mbm\(s\) {
   mix-blend-mode: saturation;
 }
@@ -86,6 +158,9 @@
 }
 .Op\(1\)\! {
   opacity: 1 !important;
+}
+.P\(10px\) {
+  padding: 10px;
 }
 .P\(1rem\) {
   padding: 1rem;
@@ -117,14 +192,20 @@
 .W\(10\/12\) {
   width: 83.3333%;
 }
+.W\(100\%\), .W\(12\/12\) {
+  width: 100%;
+}
 .W\(11\/12\) {
   width: 91.6667%;
 }
-.W\(12\/12\) {
-  width: 100%;
+.W\(160px\) {
+  width: 160px;
 }
 .W\(2\/12\) {
   width: 16.6667%;
+}
+.W\(20px\) {
+  width: 20px;
 }
 .W\(3\/12\) {
   width: 25%;

--- a/examples/css/atomic.css
+++ b/examples/css/atomic.css
@@ -58,6 +58,12 @@
 .As\(fs\) {
   align-self: flex-start;
 }
+.As\(se\) {
+  align-self: self-end;
+}
+.As\(ss\) {
+  align-self: self-start;
+}
 .As\(st\) {
   align-self: stretch;
 }

--- a/examples/html/sample-2.html
+++ b/examples/html/sample-2.html
@@ -1,2 +1,0 @@
-<div class="Bgbm(n) Mbm(pl)">Test Blend modes</div>
-<div class="foo_Bgbm(h) bar_Mbm(s)">Test parent Blend modes</div>

--- a/examples/html/sample-2.html
+++ b/examples/html/sample-2.html
@@ -1,0 +1,2 @@
+<div class="Bgbm(n) Mbm(pl)">Test Blend modes</div>
+<div class="foo_Bgbm(h) bar_Mbm(s)">Test parent Blend modes</div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -19,6 +19,7 @@
             <ul>
                 <li><a href="simple.html">Simple</a> - A "hello world" page of atomic class usage.</li>
                 <li><a href="grid.html">Grid</a> - A useful page to see different ways to markup layouts.</li>
+                <li><a href="align.html">Align</a> - A page of atomic alignments.</li>
                 <li><a href="blend-modes.html">Blend Modes</a> - A simple example using different blend mode styles.</li>
             <ul>
         </main>

--- a/packages/atomizer/src/boxAlignment.js
+++ b/packages/atomizer/src/boxAlignment.js
@@ -1,0 +1,20 @@
+module.exports = {
+    baselinePosition: {
+        'b': 'baseline'//,
+        // 'fb': 'first baseline',
+        // 'lb': 'last baseline'
+    },
+    contentDistribution: {
+        'sa': 'space-around',
+        'sb': 'space-between',
+        'se': 'space-evenly',
+        'st': 'stretch'
+    },
+    contentPosition: {
+        'c': 'center',
+        // 'e': 'end',
+        'fe': 'flex-end',
+        'fs': 'flex-start',
+        // 's': 'start'
+    }
+};

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -1498,6 +1498,7 @@ module.exports = [
         'arguments': [{
             'n': 'normal',
             's': 'stretch',
+            ...baselinePosition,
             ...contentDistribution,
             ...contentPosition
         }]
@@ -1516,6 +1517,7 @@ module.exports = [
         },
         'arguments': [{
             'n': 'normal',
+            ...baselinePosition,
             ...contentDistribution,
             ...contentPosition
         }]

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -38,8 +38,6 @@ const mixBlendModes = Object.assign(blendModes, {'pd': 'plus-darker', 'pl': 'plu
 const colors = require('./colors');
 const selfPosition = {...contentPosition, 'se': 'self-end', 'ss': 'self-start'};
 
-
-
 module.exports = [
     /**
     ==================================================================
@@ -1500,7 +1498,6 @@ module.exports = [
         },
         'arguments': [{
             'n': 'normal',
-            's': 'stretch',
             ...baselinePosition,
             ...contentDistribution,
             ...contentPosition
@@ -1551,6 +1548,7 @@ module.exports = [
             'n': 'normal',
             'l': 'left',
             'r': 'right',
+            's': 'stretch', // backwards compat
             ...contentDistribution,
             ...contentPosition
         }]

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -37,6 +37,9 @@ const blendModes = require('./blendmodes');
 const mixBlendModes = Object.assign(blendModes, {'pd': 'plus-darker', 'pl': 'plus-lighter'});
 const colors = require('./colors');
 const selfPosition = {...contentPosition, 'se': 'self-end', 'ss': 'self-start'};
+
+
+
 module.exports = [
     /**
     ==================================================================
@@ -1410,7 +1413,7 @@ module.exports = [
         'arguments': [{
             'a': 'auto',
             'n': 'normal',
-            's': 'stretch',
+            'st': 'stretch',
             ...baselinePosition,
             ...selfPosition
         }]

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -34,6 +34,7 @@
  **/
 const { baselinePosition, contentDistribution, contentPosition } = require('./boxAlignment');
 const blendModes = require('./blendmodes');
+const mixBlendModes = Object.assign(blendModes, {'pd': 'plus-darker', 'pl': 'plus-lighter'});
 const colors = require('./colors');
 const selfPosition = {...contentPosition, 'se': 'self-end', 'ss': 'self-start'};
 module.exports = [
@@ -2088,7 +2089,7 @@ module.exports = [
         'styles': {
             'mix-blend-mode': '$0'
         },
-        'arguments': [{...blendModes, 'pd': 'plus-darker', 'pl': 'plus-lighter'}]
+        'arguments': [mixBlendModes]
     },
     /**
     ==================================================================

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -1781,7 +1781,7 @@ module.exports = [
     {
         'type': 'pattern',
         'name': 'Isolation',
-        'matcher': 'I',
+        'matcher': 'Iso',
         'allowParamToValue': false,
         'styles': {
             'isolation': '$0'

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -32,10 +32,10 @@
  *   "start" and "end".
  * - Rules is written as an array because ORDER is important for the CSS generation.
  **/
+const { baselinePosition, contentDistribution, contentPosition } = require('./boxAlignment');
 const blendModes = require('./blendmodes');
-const mixBlendModes = Object.assign(blendModes, {'pd': 'plus-darker', 'pl': 'plus-lighter'});
 const colors = require('./colors');
-
+const selfPosition = {...contentPosition, 'se': 'self-end', 'ss': 'self-start'};
 module.exports = [
     /**
     ==================================================================
@@ -1396,8 +1396,8 @@ module.exports = [
         }]
     },
     // align-self (previously flex-align)
-    // Previous version: http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-align
-    // Latest version: http://www.w3.org/TR/css3-flexbox/#align-items-property
+    // Previous version: http://www.w3.org/TR/css3-flexbox/#align-items-property
+    // Latest version: https://www.w3.org/TR/css-align-3/#propdef-align-self
     {
         'type': 'pattern',
         'name': 'Align self',
@@ -1408,11 +1408,10 @@ module.exports = [
         },
         'arguments': [{
             'a': 'auto',
-            'fs': 'flex-start',
-            'fe': 'flex-end',
-            'c': 'center',
-            'b': 'baseline',
-            'st': 'stretch'
+            'n': 'normal',
+            's': 'stretch',
+            ...baselinePosition,
+            ...selfPosition
         }]
     },
     // flex-direction
@@ -1485,8 +1484,8 @@ module.exports = [
         }]
     },
     // align-items (previously flex-item-align)
-    // Previous version: http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-align
-    // Latest version: http://www.w3.org/TR/css3-flexbox/#align-items-property
+    // Previous version: http://www.w3.org/TR/css3-flexbox/#align-items-property
+    // Latest version: https://www.w3.org/TR/css-align-3/#propdef-align-items
     {
         'type': 'pattern',
         'name': 'Align items',
@@ -1496,17 +1495,16 @@ module.exports = [
             'align-items': '$0'
         },
         'arguments': [{
-            'fs': 'flex-start',
-            'fe': 'flex-end',
-            'c': 'center',
-            'b': 'baseline',
-            'st': 'stretch'
+            'n': 'normal',
+            's': 'stretch',
+            ...contentDistribution,
+            ...contentPosition
         }]
     },
     // align-content (previously flex-line-pack)
     // Source: http://msdn.microsoft.com/en-us/library/ie/jj127302%28v=vs.85%29.aspx
-    // Previous version: http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-line-pack
-    // Latest version: http://www.w3.org/TR/css3-flexbox/#align-content-property
+    // Previous version: http://www.w3.org/TR/css3-flexbox/#align-content-property
+    // Latest version: https://www.w3.org/TR/css-align-3/#propdef-align-content
     {
         'type': 'pattern',
         'name': 'Align content',
@@ -1516,12 +1514,9 @@ module.exports = [
             'align-content': '$0'
         },
         'arguments': [{
-            'fs': 'flex-start',
-            'fe': 'flex-end',
-            'c': 'center',
-            'sb': 'space-between',
-            'sa': 'space-around',
-            'st': 'stretch'
+            'n': 'normal',
+            ...contentDistribution,
+            ...contentPosition
         }]
     },
     // order (previously flex-order)
@@ -1536,9 +1531,8 @@ module.exports = [
             'order': '$0'
         }
     },
-    // justify-content (previously flex-pack)
-    // Previous version: http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-pack
-    // Latest version: http://www.w3.org/TR/css3-flexbox/#justify-content-property
+    // Previous version: http://www.w3.org/TR/css3-flexbox/#justify-content-property
+    // Latest version: https://www.w3.org/TR/css-align-3/#propdef-justify-content
     {
         'type': 'pattern',
         'name': 'Justify content',
@@ -1548,16 +1542,11 @@ module.exports = [
             'justify-content': '$0'
         },
         'arguments': [{
-            /* Positional alignment */
-            'fs': 'flex-start',
-            'fe': 'flex-end',
-            'c': 'center',
-            
-            /* Distributed alignment */
-            'sb': 'space-between',
-            'sa': 'space-around',
-            'se': 'space-evenly',
-            's':  'stretch'
+            'n': 'normal',
+            'l': 'left',
+            'r': 'right',
+            ...contentDistribution,
+            ...contentPosition
         }]
     },
     // flex-wrap
@@ -1776,6 +1765,24 @@ module.exports = [
             'a': 'auto',
             'n': 'normal',
             'm': 'manual'
+        }]
+    },
+        /**
+    ==================================================================
+    ISOLATE
+    ==================================================================
+    */
+    {
+        'type': 'pattern',
+        'name': 'Isolation',
+        'matcher': 'I',
+        'allowParamToValue': false,
+        'styles': {
+            'isolation': '$0'
+        },
+        'arguments': [{
+            'a': 'auto',
+            'i': 'isolate',
         }]
     },
     /**
@@ -2081,7 +2088,7 @@ module.exports = [
         'styles': {
             'mix-blend-mode': '$0'
         },
-        'arguments': [mixBlendModes]
+        'arguments': [{...blendModes, 'pd': 'plus-darker', 'pl': 'plus-lighter'}]
     },
     /**
     ==================================================================


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

*W3C has been developing the Box Alignment Module, which establishes a common set of alignment properties and values for use across multiple box models, including flex, grid, table and block.*
I like where they are going with grouping alignments so makes sense (to me) to follow their syntax.

e.g.

*Value:* `normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>`

# [Box alignment model](https://www.w3.org/TR/css-align-3/)

[ ]  *baseline position*: `first baseline` & `last baseline` not ready for use
https://www.w3.org/TR/2021/WD-css-align-3-20211224/#typedef-baseline-position
https://caniuse.com/mdn-css_properties_align-items_flex_context_last_baseline

[x] *Content Distribution*
https://www.w3.org/TR/2021/WD-css-align-3-20211224/#typedef-content-distribution

[ ] *overflow-position*: not ready for use
https://www.w3.org/TR/2021/WD-css-align-3-20211224/#typedef-overflow-position
https://caniuse.com/mdn-css_properties_align-items_flex_context_safe_unsafe

[ ] *content-position*: `start` and `end` not ready for use
https://www.w3.org/TR/2021/WD-css-align-3-20211224/#typedef-content-position
https://caniuse.com/mdn-css_properties_align-items_flex_context_start_end

[x] *self-position*: content-position + `self-end` & `self-start`
https://www.w3.org/TR/2021/WD-css-align-3-20211224/#typedef-self-position

[ ] Legacy values for justify-items - they may get dropped..


## Added helpers to match the updated specs eg 

```
const { baselinePosition, contentDistribution, contentPosition } = require('./boxAlignment');
const selfPosition = {...contentPosition, 'se': 'self-end', 'ss': 'self-start'};
```
**note:** I commented out some of the unusable values in these helpers - we could simply remove them for now too...

### Output

```
baselinePosition { 
    'b': 'baseline' 
}
contentDistribution {
    'sa': 'space-around',
    'sb': 'space-between',
    'se': 'space-evenly',
    'st': 'stretch'
}
contentPosition { 
    'c': 'center',
    'fe': 'flex-end',
    'fs': 'flex-start'
}
selfPosition {
    'c': 'center',
    'fe': 'flex-end',
    'fs': 'flex-start',
    'se': 'self-end',
    'ss': 'self-start'
}
```

**note: Due to using spread operator to combine rules the AFTER output below is not alphasorted **

## [align-content](https://www.w3.org/TR/css-align-3/#propdef-align-content)

Value:	`normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>`

### Before

```
'arguments': [{
    'fs': 'flex-start',
    'fe': 'flex-end',
    'c': 'center',
    'sb': 'space-between',
    'sa': 'space-around',
    'st': 'stretch'
}]
```

### After

```
'arguments': [{
    'b': 'baseline',
    'n': 'normal',
    'sa': 'space-around',
    'sb': 'space-between',
    'se': 'space-evenly',
    'st': 'stretch',
    'c': 'center',
    'fe': 'flex-end',
    'fs': 'flex-start'
}]
```

## [align-items](https://www.w3.org/TR/css-align-3/#propdef-align-items)

[Css-tricks](https://css-tricks.com/almanac/properties/j/justify-items/)

Value: `normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]`

### Before

```
'arguments': [{
    'fs': 'flex-start',
    'fe': 'flex-end',
    'c': 'center',
    'b': 'baseline',
    'st': 'stretch'
}]
```

### After

```
'arguments': [{
    'n': 'normal',
    'st': 'stretch',
    'b': 'baseline',
    'c': 'center',
    'fe': 'flex-end',
    'fs': 'flex-start'
}]
```

## [align-self](https://www.w3.org/TR/css-align-3/#propdef-align-self)

Value:	`auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position>`

### Before

```
'arguments': [{
    'a': 'auto',
    'fs': 'flex-start',
    'fe': 'flex-end',
    'c': 'center',
    'b': 'baseline',
    'st': 'stretch'
}]
```

### After

```
'arguments': [{
    'a': 'auto',
    'n': 'normal',
    's': 'stretch',
    'b': 'baseline',
    'c': 'center',
    'fe': 'flex-end',
    'fs': 'flex-start',
    'se': 'self-end',
    'ss': 'self-start'
}]
```

## [justify-content](https://www.w3.org/TR/css-align-3/#propdef-justify-content)

Value: `normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]`

### Before

```
'arguments': [{
    /* Positional alignment */
    'fs': 'flex-start',
    'fe': 'flex-end',
    'c': 'center',
    
    /* Distributed alignment */
    'sb': 'space-between',
    'sa': 'space-around',
    'se': 'space-evenly',
    's':  'stretch'
}]
```

### After

```
'arguments': [{
    'n': 'normal',
    'l': 'left',
    'r': 'right',
    'sa': 'space-around',
    'sb': 'space-between',
    'se': 'space-evenly',
    'st': 'stretch',
    'c': 'center',
    'fe': 'flex-end',
    'fs': 'flex-start'
}]
```

# [Isolation](https://www.w3.org/TR/compositing-1/#propdef-isolation)

Pretty simple this one.

## TODO

Add `Justify-items` for flex layout.

Move Align properties to be grouped, kept current order for easier initial PR..

### How Has This Been Tested?

_Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc._

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Review the following points, and put an x in all the boxes that apply. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help!

- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/acss-io/atomizer/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
