### PR TITLE
bug(atomizer): align0items incorrect values

### DIFF
--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -1497,7 +1497,6 @@ module.exports = [
             'align-items': '$0'
         },
         'arguments': [{
-            'a': 'auto',
             'n': 'normal',
             'st': 'stretch',
             ...baselinePosition,

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -1497,10 +1497,11 @@ module.exports = [
             'align-items': '$0'
         },
         'arguments': [{
+            'a': 'auto',
             'n': 'normal',
+            'st': 'stretch',
             ...baselinePosition,
-            ...contentDistribution,
-            ...contentPosition
+            ...selfPosition
         }]
     },
     // align-content (previously flex-line-pack)


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

Noticed an issue with  `align-items`. https://www.w3.org/TR/css-align-3/#propdef-align-items

should be:  
```
normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]
```

### How Has This Been Tested?

fixed:
<img width="454" alt="Screen Shot 2022-07-20 at 3 56 14 PM" src="https://user-images.githubusercontent.com/1000477/180096497-9aa3969f-a5b2-45ec-aef4-b7a4ea55af7e.png">


Previous prod and last change:
<img width="989" alt="old" src="https://user-images.githubusercontent.com/1000477/180096019-01405a73-eda2-4196-b464-ab113d3bc11a.png">
### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Review the following points, and put an x in all the boxes that apply. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help!

- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/acss-io/atomizer/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
