### PR TITLE
fix: add style block for Cf helper

### DIFF
--- a/examples/css/atomic.css
+++ b/examples/css/atomic.css
@@ -4,12 +4,6 @@
 .Bgbm\(di\) {
   background-blend-mode: difference;
 }
-.Bgbm\(n\) {
-  background-blend-mode: normal;
-}
-.foo .foo_Bgbm\(h\) {
-  background-blend-mode: hue;
-}
 .Bgc\(\#000\) {
   background-color: #000;
 }
@@ -177,12 +171,6 @@
 .Mb\(10px\) {
   margin-bottom: 10px;
 }
-.bar .bar_Mbm\(s\) {
-  mix-blend-mode: saturation;
-}
-.Mbm\(pl\) {
-  mix-blend-mode: plus-lighter;
-}
 .Mbm\(sc\) {
   mix-blend-mode: screen;
 }
@@ -201,10 +189,7 @@
 .P\(3rem\) {
   padding: 3rem;
 }
-.Td\(u\) {
-  text-decoration: underline;
-}
-.Td\(u\)\:h:hover {
+.Td\(u\), .Td\(u\)\:h:hover {
   text-decoration: underline;
 }
 .foo > .foo\>W\(uh\) {
@@ -257,6 +242,13 @@
 }
 .W\(9\/12\) {
   width: 75%;
+}
+.Cf:before, .Cf:after {
+  content: " ";
+  display: table;
+}
+.Cf:after {
+  clear: both;
 }
 @media(min-width:500px) {
   .D\(b\)--sm {

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -18,7 +18,7 @@
             
             <div class="Fz(2rem) My(1rem) P(1rem) Bdb(1) C(#ff0000)">Large Red Text</div>
             
-            <div class="H(100%) W(500px) Bgc(#000) P(3rem) C(#fff)">Big black box</div>
+            <div class="H(100%) W(500px) Bgc(#000) P(3rem) C(#fff) Cf">Big black box</div>
         </main>
 
         <!-- this is just to reload the page if you make any changes to the html -->

--- a/packages/atomizer/src/helpers.js
+++ b/packages/atomizer/src/helpers.js
@@ -162,6 +162,7 @@ module.exports = [
         'link': 'https://acss.io/guides/helper-classes.html#-cf-clearfix-',
         'matcher': 'Cf',
         'noParams': true,
+        'styles': {},
         'rules': {
             '.Cf:before, .Cf:after': {
                 'content': '" "',


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

When I [changed the `Cf` helper class](https://github.com/acss-io/atomizer/pull/448/files#diff-65751c4f29f4e5ea220240417e678b297b0c3f4e664a991370fb811fb0482349L167) to remove the IE hacks, I removed the `style` block which apparently is required to add the `:after` and `:before` styles. Without this the `Cf` class was not added in the atomic output.

### Motivation and Context

Missing `Cf` class breaks layouts.

### How Has This Been Tested?

Tested on the example site by adding `Cf` class. Also tested that adding the generated `Cf` styles to a production site fixed the layout issue.

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

