### PR TITLE
Sort arguments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,7 +92,12 @@ module.exports = function (grunt) {
 
         watch: {
             docs: {
-                files: ['<%= project.app %>/**/*', '<%= project.docs %>/**/*', '!<%= project.docs %>/_site/**/*'],
+                files: [
+                    '<%= project.app %>/**/*',
+                    '<%= project.docs %>/**/*',
+                    '!<%= project.docs %>/_site/**/*',
+                    'packages/atomizer/src/**/*'
+                ],
                 tasks: ['dev'],
                 options: {
                     spawn: false,

--- a/packages/atomizer/package.json
+++ b/packages/atomizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomizer",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "description": "A tool for creating Atomic CSS, a collection of single purpose styling units for maximum reuse",
   "main": "./src/atomizer.js",
   "typings": "./index.d.ts",

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -38,6 +38,9 @@ const mixBlendModes = Object.assign(blendModes, {'pd': 'plus-darker', 'pl': 'plu
 const colors = require('./colors');
 const selfPosition = {...contentPosition, 'se': 'self-end', 'ss': 'self-start'};
 
+// not adding to utils so it doesn't get bundled to the client
+const sortKeys = (obj) => Object.keys(obj).sort().reduce((acc, key) => { acc[key] = obj[key]; return acc; }, {});
+
 module.exports = [
     /**
     ==================================================================
@@ -1408,13 +1411,13 @@ module.exports = [
         'styles': {
             'align-self': '$0'
         },
-        'arguments': [{
+        'arguments': [sortKeys({
             'a': 'auto',
             'n': 'normal',
             'st': 'stretch',
             ...baselinePosition,
             ...selfPosition
-        }]
+        })]
     },
     // flex-direction
     {
@@ -1496,12 +1499,12 @@ module.exports = [
         'styles': {
             'align-items': '$0'
         },
-        'arguments': [{
+        'arguments': [sortKeys({
             'n': 'normal',
             'st': 'stretch',
             ...baselinePosition,
             ...selfPosition
-        }]
+        })]
     },
     // align-content (previously flex-line-pack)
     // Source: http://msdn.microsoft.com/en-us/library/ie/jj127302%28v=vs.85%29.aspx
@@ -1515,12 +1518,12 @@ module.exports = [
         'styles': {
             'align-content': '$0'
         },
-        'arguments': [{
+        'arguments': [sortKeys({
             'n': 'normal',
             ...baselinePosition,
             ...contentDistribution,
             ...contentPosition
-        }]
+        })]
     },
     // order (previously flex-order)
     // Previous version: http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-order
@@ -1544,14 +1547,14 @@ module.exports = [
         'styles': {
             'justify-content': '$0'
         },
-        'arguments': [{
+        'arguments': [sortKeys({
             'n': 'normal',
             'l': 'left',
             'r': 'right',
             's': 'stretch', // backwards compat
             ...contentDistribution,
             ...contentPosition
-        }]
+        })]
     },
     // flex-wrap
     {

--- a/packages/grunt-atomizer/package.json
+++ b/packages/grunt-atomizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-atomizer",
   "description": "Grunt task for Atomizer",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "main": "index.js",
   "contributors": [
     {


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

Currently the Reference page outputs each class argument in the order they appear in rules.js file. As we have added new rules that share arguments, the merged object is no longer sorted. Added a `sortKeys` function to sort an objects keys after the spread operation.

Before:

![Screen Shot 2022-07-21 at 12 01 49 PM](https://user-images.githubusercontent.com/193272/180295385-ee9f7d1f-ad55-457c-a008-30e9b725072a.jpg)

After:

![Screen Shot 2022-07-21 at 12 02 07 PM](https://user-images.githubusercontent.com/193272/180295424-20f7c197-dc43-43e8-8e63-2dfaa60fe300.jpg)

### How Has This Been Tested?

Local dev server

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
