### PR TITLE
feat: add toc to right side of each page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,8 +7,7 @@ node_nodules
 dist
 
 # docs
-docs/assets/js/lunr.*
-docs/assets/js/main.js
+docs/assets/js/
 docs/_site
 vendor/
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,9 +28,9 @@ module.exports = function (grunt) {
                     {
                         src: [
                             '<%= project.app %>/components/**/*.jsx',
+                            '<%= project.app %>/assets/js/*.js',
                             '<%= project.docs %>/**/*.md',
-                            '<%= project.docs %>/**/*.html',
-                            '<%= project.docs %>/assets/js/*.js'
+                            '<%= project.docs %>/**/*.html'
                         ],
                         dest: '<%= project.docs %>/assets/css/atomic.css',
                     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,7 @@ module.exports = function (grunt) {
                 entry: {
                     main: '<%= project.app %>/client-reference.js',
                     search: '<%= project.app %>/assets/js/search.js',
+                    toc: '<%= project.app %>/assets/js/toc.js',
                 },
                 output: {
                     path: path.resolve(__dirname, 'docs', 'assets', 'js'),
@@ -162,6 +163,7 @@ module.exports = function (grunt) {
                 entry: {
                     main: '<%= project.app %>/client-reference.js',
                     search: '<%= project.app %>/assets/js/search.js',
+                    toc: '<%= project.app %>/assets/js/toc.js',
                 },
                 output: {
                     path: path.resolve(__dirname, 'docs', 'assets', 'js'),

--- a/app/assets/css/custom.css
+++ b/app/assets/css/custom.css
@@ -86,6 +86,10 @@ li.selected a {
     right: 0;
 }
 
+#toc li {
+    line-height: initial;
+}
+
 /* Colors =========================================================== */
 
 /**

--- a/app/assets/css/custom.css
+++ b/app/assets/css/custom.css
@@ -117,6 +117,7 @@ code,
 
 pre code {
     background: none;
+    padding: 0;
 }
 
 /* info/warning/important/success boxes ============================= */

--- a/app/assets/js/toc.js
+++ b/app/assets/js/toc.js
@@ -1,0 +1,31 @@
+import stripChars from '../../libs/stripChars.mjs';
+const headings = document.querySelectorAll('#main h2, #main h3');
+const { length } = headings;
+const items = [];
+const tocEl = document.getElementById('toc');
+
+if (length && tocEl) {
+    let nested = false;
+    for (let x = 0; x < length; x += 1) {
+        const name = headings[x].nodeName.toLowerCase();
+        const text = headings[x].innerText.replace(/</g, '&lt;').replace(/>/g, '&gt;'); // replace < and > with HTML entities
+        const anchor = headings[x].id || stripChars(text); // use id if available, otherwise use stripped text
+
+        // handle nested list items
+        if (name === 'h3') {
+            if (!nested) {
+                items.push('<ul class="ul-list M(0) P(0) Pstart(.5em)!">');
+                nested = true;
+            } 
+            items.push(`<li class="Mstart(20px) Py(5px)"><a href="#${anchor}">${text}</a></li>`);
+            continue;
+        } else if (nested) {
+            items.push('</ul>');
+            nested = false;
+        }
+            
+        items.push(`<li class="Py(5px)"><a href="#${anchor}">${text}</a></li>`);
+    }
+    // generate markup
+    tocEl.innerHTML += `<h4 class="D(n) D(b)--lg Fz(.865rem)">On this page</h4><ul class="M(0) P(0)">${items.join('')}</ul>`;
+}

--- a/config/atomic-config.js
+++ b/config/atomic-config.js
@@ -14,7 +14,9 @@ module.exports = {
         'Bdc(light)': 'rgba(2,128,174,.3)',
         brandColor: '#0280ae',
         'Bgc(selected)': '#e5e1ea!important',
+        lineHeight: '0.8',
         primaryFontColor: '#{brandColor}',
+        tocEnd: 'max(0px,calc(50% - 40rem))',
         'Fz(RWD-fontSize)': {
             xs: '40px',
             sm: '19px',

--- a/docs/_includes/subhead.html
+++ b/docs/_includes/subhead.html
@@ -1,4 +1,4 @@
-{% assign clean_id = include.title | downcase | slugify" %}
+{% assign clean_id = include.title | downcase | replace: "&lt;", "" | replace: "&gt;", "" | slugify %}
 <{{ include.tag }} id="{{ clean_id }}">
     <a href="#{{ clean_id }}" class="C(#4c4c4c) subhead">
         {{ include.title }}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -28,6 +28,7 @@
     </body>
 
     <script src="{{ "/assets/js/search.js" | relative_url }}" async></script>
+    <script src="{{ "/assets/js/toc.js" | relative_url }}" async></script>
     <script src="https://static.codepen.io/assets/embed/ei.js" async></script>
     <script>
         (function() {

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -2,21 +2,26 @@
 layout: default
 ---
 
-<div id="toggleMenuWrapper" class="docs-page D(tb)--sm Tbl(f) Pt(20px) Mb(50px) Maw(1280px)--sm Miw(1280px)--lg Mx(a)--sm W(96%)--sm">
+<div id="toggleMenuWrapper" class="docs-page D(tb)--sm Tbl(f) Pt(20px) Mb(50px) Maw(1280px)--sm Miw(1280px)--lg Mx(a)--sm">
     <button id="toggleMenuButton" class="menu-button Bgi(hamburger) W(32px) H(32px) D(n)--sm Pos(a) Bdw(0) Bgc(t) P(0) T(0) Start(0) Z(7) M(10px) menu-on_Bgp(end_t)">
         <b class="Hidden">Toggle the menu</b>
     </button>
 
-    <aside id="aside" class="D(tbc) Bgc(#fff) Mt(-20px)--xs Pos(a)--xs Va(t) W(150px)--sm W(250px)--md End(0) Pt(20px) Pb(40px) menu-on_Px(10px) Pend(50px)--sm Z(5) End(a)--sm Start(0) Pos(a) Pos(r)--sm">
+    <aside id="aside" class="D(tbc) Bgc(#fff) Mt(-20px)--xs Pos(a)--xs Va(t) W(250px)--sm End(0) Pt(20px) Pb(40px) menu-on_Px(10px) Pstart(10px)--sm Pstart(0px)--lg Pend(50px)--sm Z(5) End(a)--sm Start(0) Pos(r)--sm">
         {% include menu.html %}
     </aside>
 
     <main id="main" class="D(tbc)--sm home_D(b)! Px(10px) menu-on_Pos(f)">
-        <div class="D(f)--sm Ai(c) Jc(sb)">
-            <h1 class="Fz(30px)">{{ page.title }}</h1>
-            <a href="{{ page.githubDocsPath }}{{ page.path }}" class="Mt(25px)" target='_blank'>Edit on Github</a>
+        <h1 class="Fz(30px)">{{ page.title }}</h1>
+
+        <div class="D(f)--lg">
+            <div id="toc" class="Pos(f)--lg Ovy(a) T(5em) B(0) End(tocEnd)--lg Or(2)--md W(200px)--lg"></div>
+            <div class="W(75%)--sm">
+                <div>{{ content }}</div>
+            </div>
         </div>
-        <div>{{ content }}</div>
+
+        <a href="{{ page.githubDocsPath }}{{ page.path }}" class="Mt(25px)" target='_blank'>Edit on Github</a>
     </main>
 
     <div id="overlay" class="D(n) D(n)!--sm menu-on_D(b) Bgc(#000.6) Z(3) Pos(f) T(0) Start(0) W(100%) H(100%)"></div>

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -7,7 +7,7 @@ layout: default
         <b class="Hidden">Toggle the menu</b>
     </button>
 
-    <aside id="aside" class="D(tbc) Bgc(#fff) Mt(-20px)--xs Pos(a)--xs Va(t) W(250px)--sm End(0) Pt(20px) Pb(40px) menu-on_Px(10px) Pstart(10px)--sm Pstart(0px)--lg Pend(50px)--sm Z(5) End(a)--sm Start(0) Pos(r)--sm">
+    <aside id="aside" class="D(tbc) Bgc(#fff) Mt(-20px)--xs Pos(a)--xs Pos(r) Va(t) W(250px)--sm End(0) Pt(20px) Pb(40px) menu-on_Px(10px) Pstart(10px)--sm Pstart(0px)--lg Pend(50px)--sm Z(5) End(a)--sm Start(0)">
         {% include menu.html %}
     </aside>
 

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -12,10 +12,10 @@ layout: default
     </aside>
 
     <main id="main" class="D(tbc)--sm home_D(b)! Px(10px) menu-on_Pos(f)">
-        <h1 class="Fz(30px)">{{ page.title }}</h1>
+        <h1 class="Fz(20px) Fz(30px)--sm Mb(20px)--xs">{{ page.title }}</h1>
 
         <div class="D(f)--lg">
-            <div id="toc" class="Pos(f)--lg Ovy(a) T(5em) B(0) End(tocEnd)--lg Or(2)--md W(200px)--lg"></div>
+            <div id="toc" class="Pos(f)--lg Ovy(a) T(5em) B(0) End(tocEnd)--lg Or(2)--md W(200px)--lg Mt(1em) Mt(0)--lg"></div>
             <div class="W(75%)--sm">
                 <div>{{ content }}</div>
             </div>

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -6,33 +6,7 @@ title: Frequently Asked Questions
 
 <p>This section is intended to answer common questions related to Atomic CSS and Atomizer. If you&#39;re unable to find an answer to your question, <a href="/support.html">you can find support here</a> or <a href="https://github.com/acss-io/atomizer/discussions">start a discussion here</a>.</p>
 
-<h2 id="questions-related-to-the-atomic-css-architecture">Questions related to the Atomic CSS architecture</h2>
-
-<ul class="ul-list">
-   <li><a href="#what-is-atomic-css-">What is Atomic CSS?</a></li>
-   <li><a href="#how-is-atomic-css-different-than-using-inline-styles-">How is Atomic CSS different than using inline styles?</a></li>
-   <li><a href="#what-are-the-benefits-of-atomic-css-">What are the benefits of Atomic CSS?</a></li>
-   <li><a href="#should-i-style-everything-using-atomic-classes-">Should I style everything using atomic classes?</a></li>
-   <li><a href="#i-have-always-been-told-to-use-classes-related-to-content-not-to-presentation-isn-t-atomic-css-promoting-bad-practice-">I have always been told to use classes related to content, <em>not to presentation</em>. Isn&#39;t Atomic CSS promoting bad practice?</a></li>
-   <li><a href="#isn-t-atomic-css-moving-bloat-from-style-sheets-to-html-">Isn&#39;t Atomic CSS moving bloat from style sheets to HTML?</a></li>
-   <li><a href="#how-can-you-distribute-presentation-changes-without-asking-everyone-to-change-their-markup-">How can you distribute presentation changes without asking everyone to change their markup?</a></li>
-   <li><a href="#how-does-atomic-css-work-with-abbr-title-responsive-web-design-rwd-abbr-">How does Atomic CSS work with Responsive Web Design (RWD)?</a></li>
-</ul>
-
-<h2 id="questions-related-to-atomizer">Questions related to Atomizer</h2>
-
-<ul class="ul-list">
-   <li><a href="#how-does-atomizer-css-compare-to-bootstrap-purecss-or-other-css-framework-">How does Atomizer compare to Bootstrap, PureCSS, or other CSS frameworks?</a></li>
-   <li><a href="#do-i-need-to-specify-a-namespace-and-if-yes-what-should-i-use-">Do I need to specify a namespace? And if yes, what should I use?</a></li>
-   <li><a href="#why-are-atomizer-classes-capitalized-as-far-as-i-know-no-other-framework-does-that-">Why are Atomizer classes capitalized? As far as I know, no other framework does that?</a></li>
-   <li><a href="#why-do-i-have-to-use-lowercase-for-color-values-">Why do I have to use lowercase for colors?</a></li>
-   <li><a href="#why-are-descendant-classes-not-relying-on-the-namespace-why-are-those-styles-using-important-">Why are &quot;descendant classes&quot; not relying on the namespace? Why are those styles using <code>!important</code></a>?</li>
-   <li><a href="#how-can-one-remember-atomic-class-names-">How can one remember Atomic class names?</a></li>
-   <li><a href="#how-come-atomizer-is-not-creating-some-classes-for-me-">How come Atomizer is not creating some classes for me?</a></li>
-   <li><a href="#how-come-atomizer-does-not-add-vendor-prefixes-where-needed-">How come Atomizer does not add vendor prefixes where needed?</a></li>
-</ul>
-
-<h2 id="answers-related-to-the-atomic-css-architecture">Answers related to the Atomic CSS architecture</h2>
+<h2 id="atomic-css-architecture">Atomic CSS architecture</h2>
 
 <h3 id="what-is-atomic-css-">What is Atomic CSS?</h3>
 
@@ -45,6 +19,7 @@ title: Frequently Asked Questions
 <p class="noteBox info">Note that the above materials are relatively &quot;old&quot; and some of their content may have changed.</p>
 
 <h3 id="how-is-atomic-css-different-than-using-inline-styles-">How is Atomic CSS different than using inline styles?</h3>
+
 <dl class="dl-list">
     <dt>Inline styling, the bad parts:</dt>
     <dd>High specificity, verbosity, the inability to deal with pseudo-classes or pseudo-elements, and the fact that those bytes are not cached</dd>

--- a/docs/guides/syntax.md
+++ b/docs/guides/syntax.md
@@ -9,7 +9,7 @@ title: Class syntax
 {% include subhead.html tag="h2" title="The syntax" %}
 
 <pre>
-[<b><a href="#context">&lt;context></a></b>[<b>:<a href="#pseudo-class">&lt;pseudo-class></a></b>]<b><a href="#combinator">&lt;combinator></a></b>]<b class="Fw(b)"><a  href="#style">&lt;Style></a></b>[(<b><a href="#value">&lt;value></a>,<a href="#value">&lt;value></a>?,...</b>)][<b><a href="#-">&lt;!></a></b>][<b><a href="#pseudo-class">:&lt;pseudo-class></a></b>][<b><a href="#pseudo-element">::&lt;pseudo-element></a></b>][<b>--<a href="#breakpoint_identifier">&lt;breakpoint_identifier></a></b>]
+[<b><a href="#context">&lt;context></a></b>[<b>:<a href="#pseudo-class">&lt;pseudo-class></a></b>]<b><a href="#combinator">&lt;combinator></a></b>]<b class="Fw(b)"><a  href="#style">&lt;Style></a></b>[(<b><a href="#value">&lt;value></a>,<a href="#value">&lt;value></a>?,...</b>)][<b><a href="#-">&lt;!></a></b>][<b><a href="#pseudo-class">:&lt;pseudo-class></a></b>][<b><a href="#pseudo-element">::&lt;pseudo-element></a></b>][<b>--<a href="#breakpoint-identifier">&lt;breakpoint_identifier></a></b>]
 </pre>
 
 <p>At its core, a <b class="Fw(b)">ACSS</b> or Helper class is represented by a <a href="#style">&lt;Style&gt;</a>. </p>
@@ -26,7 +26,7 @@ title: Class syntax
 
 <p>For example, <code>Mend(2px)</code> maps to <code>margin-right: 2px</code> in a LTR context and <code>margin-left: 2px</code> in an RTL context, and <code>Pstart(1em)</code> would map to <code>padding-left: 1em</code> in a LTR context, etc.</p>
 
-<h2 id="examples-">Examples:</h2>
+{% include subhead.html tag="h2" title="Examples" %}
 
 <table class="Ta(start) W(100%)">
     <caption class="Hidden">Atomic class Examples</caption>


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

Adding TOC to make it easier to see what is on the page. Since jekyll/github doesn't support TOC out of the box, I had to create it via JS. On large desktop sizes it shows up on the right of the content. For smaller/mobile sizes, it shows up stacked above the content.

![acss-toc](https://user-images.githubusercontent.com/193272/180881233-315ed2d1-2f9b-49bc-af54-84b99af3d1a1.gif)

