### PR TITLE
Scroll snap

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -57,4 +57,7 @@
     <li class="{% if page.url == '/tutorials/alignment.html' %}selected{% endif %}">
         <a class="D(b) Td(n):h Py(5px) Pos(r)" href="{{ "/tutorials/alignment.html" | relative_url }}">Alignment</a>
     </li>
+    <li class="{% if page.url == '/tutorials/scroll.html' %}selected{% endif %}">
+        <a class="D(b) Td(n):h Py(5px) Pos(r)" href="{{ "/tutorials/scroll.html" | relative_url }}">Scroll Snap</a>
+    </li>
 </ul>

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -1,0 +1,130 @@
+---
+section: docs
+layout: docs
+title: Scroll Snap
+---
+
+These examples shows the various scroll snap properties supported by atomic.
+
+### `scroll-behavior` construct
+
+The scroll-behavior CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`.
+
+```html
+<div class="Sb(s)">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
+</div>
+```
+
+<div class="Sb(s) Sst(x_m) Ovx(s) Ovy(h) W(200px) H(200px) D(f) Mt(20px)">
+    <div class="Ssa(s) Miw(200px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">1</div>
+    <div class="Ssa(s) Miw(200px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">2</div>
+    <div class="Ssa(s) Miw(200px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
+</div>
+
+
+### `scroll-snap-align` construct
+
+You can specify up to 2 values for this property, representing the block and inline axes, respectively. If you only give 1 value, that value will be used for both axes.
+
+```html
+<div class="Sb(s)">
+    <div class="Ssa(s)">1</div>
+    <div class="Ssa(c)">2</div>
+    <div class="Ssa(e)">3</div>
+</div>
+```
+
+<div class="Sb(s) Sst(x_m) Ovx(s) Ovy(h) W(200px) H(200px) D(f) Mt(20px)">
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">1</div>
+    <div class="Ssa(c) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">2</div>
+    <div class="Ssa(e) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
+</div>
+
+
+### `scroll-snap-type` construct
+
+The `scroll-snap-type` property specifies whether a scroll container is a scroll snap container, how strictly it snaps, and which axes are considered. If no strictness value is specified, proximity is assumed.
+
+
+```html
+<div class="Sb(s) Sst(x_p)">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
+</div>
+```
+
+<div class="Sb(s) Sst(x_p) Ovx(s) Ovy(h) W(160px) H(200px) D(f) Mt(20px)">
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">1</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">2</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
+</div>
+
+### `scroll-margin` && `scroll-margin-*` constructs
+
+The `scroll-margin` shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container.
+
+```html
+<div class="Sb(s) Sst(x_m)">
+    <div>1</div>
+    <div class="Smstart(2em)">2</div>
+    <div>3</div>
+</div>
+```
+
+<div class="Sb(s) Sst(x_m) Ovx(s) Ovy(h) W(180px) H(200px) D(f) Gp(20px) Mt(20px)">
+    <div class="Ssa(c) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">1</div>
+    <div class="Ssa(c) Smstart(2em) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">2</div>
+    <div class="Ssa(c) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
+</div>
+
+
+### `scroll-padding` & `scroll-padding-*`constructs
+
+The `scroll-padding` shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element.
+
+
+```html
+<div class="Sb(s) Sst(x_m) Spx(20px) Px(20px)">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
+    ...
+</div>
+```
+
+<div class="Sb(s) Sst(x_m) Ovx(s) Ovy(h) Maw(738px) H(200px) D(f) Gp(20px) Spx(20px) Px(20px) Bdc(#add8e6) Bdw(1px) Bds(s) Mt(20px)">
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">1</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">2</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">4</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">5</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">6</div>
+    <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">7 </div>
+</div>
+
+### `scroll-snap-stop` construct
+
+The `scroll-snap-stop` CSS property defines whether or not the scroll container is allowed to "pass over" possible snap positions.
+
+```html
+<div class="Sb(s) Sst(x_m)">
+    <div class="Ssa(a)">1</div>
+    <div class="Ssa(a)">2</div>
+    <div class="Ssa(a)">3</div>
+    ...
+</div>
+```
+
+<div class="Sb(s) Sst(x_m) Sss(a) Ovx(s) Ovy(h) W(160px) H(200px) D(f) Gp(20px) Spx(20px) Px(20px) Bdc(#add8e6) Bdw(1px) Bds(s) Mt(20px)">
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">1</div>
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">2</div>
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">4</div>
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">5</div>
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#ccc)">6</div>
+    <div class="Ssa(s) Sss(a) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">7 </div>
+</div>

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -6,9 +6,9 @@ title: Scroll Snap
 
 These examples shows the various scroll snap properties supported by Atomizer.
 
-### `scroll-behavior` construct
+### [scroll-behavior](/reference#scrollbehavior) construct
 
-The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`.
+The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`. Following example shows `Sb(s)`, *scroll-behavior: smooth*.
 
 ```html
 <div class="Sb(s)">
@@ -25,9 +25,9 @@ The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-be
 </div>
 
 
-### `scroll-snap-align` construct
+### [scroll-snap-align](/reference#scrollsnapalign) construct
 
-You can specify up to 2 values for this property, representing the block and inline axes, respectively. If you only give 1 value, that value will be used for both axes.
+The [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) property specifies the box's snap position as an alignment of its snap area (as the alignment subject) within its snap container's snapport (as the alignment container). You can specify up to 2 values for this property, representing the block and inline axes, respectively. If you only give 1 value, that value will be used for both axes. Following example shows `Ssa(s)`, *scroll-snap-align: start*.
 
 ```html
 <div class="Sb(s)">
@@ -44,13 +44,12 @@ You can specify up to 2 values for this property, representing the block and inl
 </div>
 
 
-### `scroll-snap-type` construct
+### [scroll-snap-type](/reference#scrollsnaptype) construct
 
-The `scroll-snap-type` property specifies whether a scroll container is a scroll snap container, how strictly it snaps, and which axes are considered. If no strictness value is specified, proximity is assumed.
-
+The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) property specifies whether a scroll container is a scroll snap container, how strictly it snaps, and which axes are considered. If no strictness value is specified, proximity is assumed. Following example shows `Sst(x_p)`, *scroll-snap-type: x proximity*.
 
 ```html
-<div class="Sb(s) Sst(x_p)">
+<div class="Sst(x_p)">
     <div>1</div>
     <div>2</div>
     <div>3</div>
@@ -63,12 +62,12 @@ The `scroll-snap-type` property specifies whether a scroll container is a scroll
     <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
 </div>
 
-### `scroll-margin` && `scroll-margin-*` constructs
+### [scroll-margin](/reference#scrollmarginalledges) && [scroll-margin-*](/reference#scrollmargintop) constructs
 
-The `scroll-margin` shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container.
+The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container. Following example shows `Smstart(2em)`, *scroll-margin-left: 2em*.
 
 ```html
-<div class="Sb(s) Sst(x_m)">
+<div>
     <div>1</div>
     <div class="Smstart(2em)">2</div>
     <div>3</div>
@@ -82,13 +81,13 @@ The `scroll-margin` shorthand property sets scroll margin on all sides of an ele
 </div>
 
 
-### `scroll-padding` & `scroll-padding-*`constructs
+### [scroll-padding](/reference#scrollpaddingalledges) & [scroll-padding-*](/reference#scrollpaddingtop)constructs
 
-The `scroll-padding` shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element.
+The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element. Following example shows `Spx(20px)`, *scroll-padding-left: 20px; scroll-padding-right: 20px;*.
 
 
 ```html
-<div class="Sb(s) Sst(x_m) Spx(20px) Px(20px)">
+<div class="Spx(20px)">
     <div>1</div>
     <div>2</div>
     <div>3</div>
@@ -106,15 +105,15 @@ The `scroll-padding` shorthand property sets scroll padding on all sides of an e
     <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">7 </div>
 </div>
 
-### `scroll-snap-stop` construct
+### [scroll-snap-stop](/reference#scrollsnapstop) construct
 
-The `scroll-snap-stop` CSS property defines whether or not the scroll container is allowed to "pass over" possible snap positions.
+The [scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) CSS property defines whether or not the scroll container is allowed to "pass over" possible snap positions. Following example shows `Sst(x_m)`, *scroll-snap-stop: x mandatory*.
 
 ```html
-<div class="Sb(s) Sst(x_m)">
-    <div class="Ssa(a)">1</div>
-    <div class="Ssa(a)">2</div>
-    <div class="Ssa(a)">3</div>
+<div class="Sst(x_m)">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
     ...
 </div>
 ```

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -6,7 +6,7 @@ title: Scroll Snap
 
 These examples shows the various scroll snap properties supported by Atomizer.
 
-### [scroll-behavior](/reference#scrollbehavior) construct
+### [scroll-behavior](../reference.html#scrollbehavior) construct
 
 The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`. 
 
@@ -27,7 +27,7 @@ Following example shows `Sb(s)` = `scroll-behavior: smooth`.
 </div>
 
 
-### [scroll-snap-align](/reference#scrollsnapalign) construct
+### [scroll-snap-align](../reference.html#scrollsnapalign) construct
 
 The [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) property specifies the box's snap position as an alignment of its snap area (as the alignment subject) within its snap container's snapport (as the alignment container). You can specify up to 2 values for this property, representing the block and inline axes, respectively. If you only give 1 value, that value will be used for both axes. 
 
@@ -48,7 +48,7 @@ Following example shows `Ssa(s)` = `scroll-snap-align: start`.
 </div>
 
 
-### [scroll-snap-type](/reference#scrollsnaptype) construct
+### [scroll-snap-type](../reference.html#scrollsnaptype) construct
 
 The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) property specifies whether a scroll container is a scroll snap container, how strictly it snaps, and which axes are considered. If no strictness value is specified, proximity is assumed. 
 
@@ -68,7 +68,7 @@ Following example shows `Sst(x_p)` = `scroll-snap-type: x proximity`.
     <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">3</div>
 </div>
 
-### [scroll-margin](/reference#scrollmarginalledges) && [scroll-margin-*](/reference#scrollmargintop) constructs
+### [scroll-margin](../reference.html#scrollmarginalledges) && [scroll-margin-*](../reference.html#scrollmargintop) constructs
 
 The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element, can also use longhand versions like [scroll-margin-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-left) etc. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container. 
 
@@ -89,7 +89,7 @@ Following example shows `Smstart(2em)` = `scroll-margin-left: 2em`.
 </div>
 
 
-### [scroll-padding](/reference#scrollpaddingalledges) & [scroll-padding-*](/reference#scrollpaddingtop)constructs
+### [scroll-padding](../reference.html#scrollpaddingalledges) & [scroll-padding-*](../reference.html#scrollpaddingtop)constructs
 
 The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element, can also use longhand versions like [scroll-padding-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-left) etc. 
 
@@ -115,7 +115,7 @@ Following example shows `Spx(20px)` = `scroll-padding-left: 20px; scroll-padding
     <div class="Ssa(s) Miw(160px) H(200px) D(f) Ai(c) Jc(c) Fz(2em) Bgc(#add8e6) C(#ff)">7 </div>
 </div>
 
-### [scroll-snap-stop](/reference#scrollsnapstop) construct
+### [scroll-snap-stop](../reference.html#scrollsnapstop) construct
 
 The [scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) CSS property defines whether or not the scroll container is allowed to "pass over" possible snap positions. 
 

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -8,7 +8,7 @@ These examples shows the various scroll snap properties supported by Atomizer.
 
 ### `scroll-behavior` construct
 
-The scroll-behavior CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`.
+The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`.
 
 ```html
 <div class="Sb(s)">

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -4,7 +4,7 @@ layout: docs
 title: Scroll Snap
 ---
 
-These examples shows the various scroll snap properties supported by atomic.
+These examples shows the various scroll snap properties supported by Atomizer.
 
 ### `scroll-behavior` construct
 

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -64,7 +64,7 @@ The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-s
 
 ### [scroll-margin](/reference#scrollmarginalledges) && [scroll-margin-*](/reference#scrollmargintop) constructs
 
-The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container. Following example shows `Smstart(2em)`, *scroll-margin-left: 2em*.
+The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element, can also use longhand versions like [scroll-margin-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-left) etc. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container. Following example shows `Smstart(2em)`, *scroll-margin-left: 2em*.
 
 ```html
 <div>
@@ -83,7 +83,7 @@ The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-marg
 
 ### [scroll-padding](/reference#scrollpaddingalledges) & [scroll-padding-*](/reference#scrollpaddingtop)constructs
 
-The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element. Following example shows `Spx(20px)`, *scroll-padding-left: 20px; scroll-padding-right: 20px;*.
+The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element, can also use longhand versions like [scroll-padding-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-left) etc. Following example shows `Spx(20px)`, *scroll-padding-left: 20px; scroll-padding-right: 20px;*.
 
 
 ```html

--- a/docs/tutorials/scroll.md
+++ b/docs/tutorials/scroll.md
@@ -8,7 +8,9 @@ These examples shows the various scroll snap properties supported by Atomizer.
 
 ### [scroll-behavior](/reference#scrollbehavior) construct
 
-The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`. Following example shows `Sb(s)`, *scroll-behavior: smooth*.
+The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) CSS property sets the behavior for a scrolling box when scrolling is triggered by the navigation, `CSSOM` scrolling APIs or `SCROLL-SNAP`. 
+
+Following example shows `Sb(s)` = `scroll-behavior: smooth`.
 
 ```html
 <div class="Sb(s)">
@@ -27,7 +29,9 @@ The [scroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-be
 
 ### [scroll-snap-align](/reference#scrollsnapalign) construct
 
-The [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) property specifies the box's snap position as an alignment of its snap area (as the alignment subject) within its snap container's snapport (as the alignment container). You can specify up to 2 values for this property, representing the block and inline axes, respectively. If you only give 1 value, that value will be used for both axes. Following example shows `Ssa(s)`, *scroll-snap-align: start*.
+The [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) property specifies the box's snap position as an alignment of its snap area (as the alignment subject) within its snap container's snapport (as the alignment container). You can specify up to 2 values for this property, representing the block and inline axes, respectively. If you only give 1 value, that value will be used for both axes. 
+
+Following example shows `Ssa(s)` = `scroll-snap-align: start`.
 
 ```html
 <div class="Sb(s)">
@@ -46,7 +50,9 @@ The [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-
 
 ### [scroll-snap-type](/reference#scrollsnaptype) construct
 
-The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) property specifies whether a scroll container is a scroll snap container, how strictly it snaps, and which axes are considered. If no strictness value is specified, proximity is assumed. Following example shows `Sst(x_p)`, *scroll-snap-type: x proximity*.
+The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) property specifies whether a scroll container is a scroll snap container, how strictly it snaps, and which axes are considered. If no strictness value is specified, proximity is assumed. 
+
+Following example shows `Sst(x_p)` = `scroll-snap-type: x proximity`.
 
 ```html
 <div class="Sst(x_p)">
@@ -64,7 +70,9 @@ The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-s
 
 ### [scroll-margin](/reference#scrollmarginalledges) && [scroll-margin-*](/reference#scrollmargintop) constructs
 
-The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element, can also use longhand versions like [scroll-margin-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-left) etc. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container. Following example shows `Smstart(2em)`, *scroll-margin-left: 2em*.
+The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) shorthand property sets scroll margin on all sides of an element at once, much like the `margin` property does for margin on an element, can also use longhand versions like [scroll-margin-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-left) etc. If all elements have the same spacing requirements, consider using `scroll-padding` on the parent container instead of `scroll-margin` because that affects spacing for all elements within the container. 
+
+Following example shows `Smstart(2em)` = `scroll-margin-left: 2em`.
 
 ```html
 <div>
@@ -83,7 +91,9 @@ The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-marg
 
 ### [scroll-padding](/reference#scrollpaddingalledges) & [scroll-padding-*](/reference#scrollpaddingtop)constructs
 
-The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element, can also use longhand versions like [scroll-padding-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-left) etc. Following example shows `Spx(20px)`, *scroll-padding-left: 20px; scroll-padding-right: 20px;*.
+The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) shorthand property sets scroll padding on all sides of an element at once, much like the `padding` property does for padding on an element, can also use longhand versions like [scroll-padding-left](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-left) etc. 
+
+Following example shows `Spx(20px)` = `scroll-padding-left: 20px; scroll-padding-right: 20px;`.
 
 
 ```html
@@ -107,7 +117,9 @@ The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-pad
 
 ### [scroll-snap-stop](/reference#scrollsnapstop) construct
 
-The [scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) CSS property defines whether or not the scroll container is allowed to "pass over" possible snap positions. Following example shows `Sst(x_m)`, *scroll-snap-stop: x mandatory*.
+The [scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) CSS property defines whether or not the scroll container is allowed to "pass over" possible snap positions. 
+
+Following example shows `Sst(x_m)` = `scroll-snap-stop: x mandatory`.
 
 ```html
 <div class="Sst(x_m)">

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -2315,13 +2315,7 @@ module.exports = [
         'allowParamToValue': true,
         'styles': {
             'padding': '$0'
-        },
-        'arguments': [{
-            'a': 'auto',
-            'h': 'hidden',
-            's': 'scroll',
-            'v': 'visible'
-        }]
+        }
     },
     // X axis
     {
@@ -2479,15 +2473,21 @@ module.exports = [
             'scroll-snap-align': '$0'
         },
         'arguments': [{
-            'n': 'none',
             'c': 'center',
             'c_e': 'center end',
+            'c_n': 'center none',
             'c_s': 'center start',
             'e': 'end',
             'e_c': 'end center',
+            'e_n': 'end none',
             'e_s': 'end start',
+            'n': 'none',
+            'n_c': 'none center',
+            'n_e': 'none end',
+            'n_s': 'none start',
             's': 'start',
             's_c': 'start center',
+            's_n': 'start none',
             's_e': 'start end'
         }]
     },

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -2315,7 +2315,13 @@ module.exports = [
         'allowParamToValue': true,
         'styles': {
             'padding': '$0'
-        }
+        },
+        'arguments': [{
+            'a': 'auto',
+            'h': 'hidden',
+            's': 'scroll',
+            'v': 'visible'
+        }]
     },
     // X axis
     {
@@ -2444,6 +2450,256 @@ module.exports = [
             'b': 'both',
             'h': 'horizontal',
             'v': 'vertical'
+        }]
+    },
+    /**
+    ==================================================================
+    SCROLL
+    ==================================================================
+    */
+    {
+        'type': 'pattern',
+        'name': 'Scroll Behavior',
+        'matcher': 'Sb',
+        'allowParamToValue': false,
+        'styles': {
+            'scroll-behavior': '$0'
+        },
+        'arguments': [{
+            'a': 'auto',
+            's': 'smooth'
+        }]
+    },
+    {
+        'type': 'pattern',
+        'name': 'Scroll Snap Align',
+        'matcher': 'Ssa',
+        'allowParamToValue': false,
+        'styles': {
+            'scroll-snap-align': '$0'
+        },
+        'arguments': [{
+            'n': 'none',
+            'c': 'center',
+            'c_e': 'center end',
+            'c_s': 'center start',
+            'e': 'end',
+            'e_c': 'end center',
+            'e_s': 'end start',
+            's': 'start',
+            's_c': 'start center',
+            's_e': 'start end'
+        }]
+    },
+    {
+        'type': 'pattern',
+        'name': 'Scroll Snap Type',
+        'matcher': 'Sst',
+        'allowParamToValue': false,
+        'styles': {
+            'scroll-snap-type': '$0'
+        },
+        'arguments': [{
+            'b': 'block',
+            'b_m': 'block mandatory',
+            'b_p': 'block proximity',
+            'bo': 'both',
+            'bo_m': 'both mandatory',
+            'bo_p': 'both proximity',
+            'i': 'inline',
+            'i_m': 'inline mandatory',
+            'i_p': 'inline proximity',
+            'n': 'none',
+            'x': 'x',
+            'x_m': 'x mandatory',
+            'x_p': 'x proximity',
+            'y': 'y',
+            'y_m': 'y mandatory',
+            'y_p': 'y proximity',
+        }]
+    },
+    {
+        'type': 'pattern',
+        'name': 'Scroll Snap Stop',
+        'matcher': 'Sss',
+        'allowParamToValue': false,
+        'styles': {
+            'scroll-snap-stop': '$0'
+        },
+        'arguments': [{
+            'a': 'always',
+            'n': 'normal'
+        }]
+    },
+    /**
+    ==================================================================
+    SCROLL MARGIN
+    ==================================================================
+    */
+    // all edges
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin (all edges)',
+        'matcher': 'Sm',
+        'shorthand': true,
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin': '$0'
+        }
+    },
+    // X axis
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin (X axis)',
+        'matcher': 'Smx',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin-__START__': '$0',
+            'scroll-margin-__END__': '$0'
+        }
+    },
+    // Y axis
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin (Y axis)',
+        'matcher': 'Smy',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin-top': '$0',
+            'scroll-margin-bottom': '$0'
+        }
+    },
+    // top
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin top',
+        'matcher': 'Smt',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin-top': '$0'
+        }
+    },
+    // end
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin end',
+        'matcher': 'Smend',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin-__END__': '$0'
+        }
+    },
+    // bottom
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin bottom',
+        'matcher': 'Smb',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin-bottom': '$0'
+        }
+    },
+    // start
+    {
+        'type': 'pattern',
+        'name': 'Scroll margin start',
+        'matcher': 'Smstart',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-margin-__START__': '$0'
+        }
+    },
+    /**
+    ==================================================================
+    SCROLL PADDING
+    ==================================================================
+    */
+    // all edges
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding (all edges)',
+        'matcher': 'Sp',
+        'shorthand': true,
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding': '$0'
+        },
+        'arguments': [{
+            'a': 'auto'
+        }]
+    },
+    // X axis
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding (X axis)',
+        'matcher': 'Spx',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding-__START__': '$0',
+            'scroll-padding-__END__': '$0'
+        }
+    },
+    // Y axis
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding (Y axis)',
+        'matcher': 'Spy',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding-top': '$0',
+            'scroll-padding-bottom': '$0'
+        }
+    },
+    // top
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding top',
+        'matcher': 'Spt',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding-top': '$0'
+        },
+        'arguments': [{
+            'a': 'auto'
+        }]
+    },
+    // end
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding end',
+        'matcher': 'Spend',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding-__END__': '$0'
+        },
+        'arguments': [{
+            'a': 'auto'
+        }]
+    },
+    // bottom
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding bottom',
+        'matcher': 'Spb',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding-bottom': '$0'
+        },
+        'arguments': [{
+            'a': 'auto'
+        }]
+    },
+    // start
+    {
+        'type': 'pattern',
+        'name': 'Scroll padding start',
+        'matcher': 'Spstart',
+        'allowParamToValue': true,
+        'styles': {
+            'scroll-padding-__START__': '$0'
+        },
+        'arguments': [{
+            'a': 'auto'
         }]
     },
     /**


### PR DESCRIPTION
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---
# [CSS Scroll Snap](https://web.dev/css-scroll-snap/)

Adding the CSS Scroll Snap properties, great for carousels as in the example above.

## [Scroll behaviour](https://drafts.csswg.org/css-overflow/#propdef-scroll-behavior)

Value: `auto | smooth`

<img width="498" alt="Screen Shot 2022-08-05 at 1 03 41 PM" src="https://user-images.githubusercontent.com/1000477/183154045-092fe11b-6543-4371-952a-7eb44b931854.png">


## [Scroll snap type](https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-type)

Value: `none | [ x | y | block | inline | both ] [ mandatory | proximity ]?`

<img width="544" alt="Screen Shot 2022-08-05 at 1 04 00 PM" src="https://user-images.githubusercontent.com/1000477/183154105-605498e0-3f98-4b9b-bd81-4893ea080342.png">


## [Scroll snap align](https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-align)

Value:	`[ none | start | end | center ]{1,2}`

<img width="509" alt="Screen Shot 2022-08-05 at 1 08 39 PM" src="https://user-images.githubusercontent.com/1000477/183154976-ff1edbdd-08bf-483a-867b-26ed6b38a925.png">


when two values are set first is block, second is inline

## [scroll-padding](https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding)

Value:	`[ auto | <length-percentage [0,∞]> ]{1,4}`

**Q: Should we add `auto` for `Spx` & `Spy` ?**

<img width="788" alt="Screen Shot 2022-08-05 at 1 04 52 PM" src="https://user-images.githubusercontent.com/1000477/183154227-e0518073-585b-43e0-8d8c-3a947fefce97.png">


## [scroll-margin](https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin)

Value:	`<length>{1,4}`

<img width="741" alt="Screen Shot 2022-08-05 at 1 05 05 PM" src="https://user-images.githubusercontent.com/1000477/183154308-c911bf97-5c54-4d87-b953-15f7d94e9963.png">


## [scroll-snap-stop](https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop)

Value:	`normal | always`

<img width="558" alt="Screen Shot 2022-08-05 at 1 05 30 PM" src="https://user-images.githubusercontent.com/1000477/183154354-541d5577-133e-4024-88bd-43d469d38649.png">


## TBD

There are some extra properties I have not added, not sure we have much use case for them at the moment - open to discussion..

[Flow-relative Longhands for scroll-padding](https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical)

[Flow-relative Longhands for scroll-margin](https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical)


![localhost_4000_tutorials_scroll html](https://user-images.githubusercontent.com/1000477/183150512-0eb468c6-e5ac-48f1-9414-00eccee59afe.png)

