### PR TITLE
fix(atomizer): show hex value in warning

### DIFF
--- a/.changeset/beige-rules-brake.md
+++ b/.changeset/beige-rules-brake.md
@@ -1,0 +1,5 @@
+---
+'atomizer': patch
+---
+
+fix(atomizer): show hex value in warning

--- a/packages/atomizer/src/atomizer.js
+++ b/packages/atomizer/src/atomizer.js
@@ -288,7 +288,7 @@ Atomizer.prototype.parseConfig = function (config /*:AtomizerConfig*/, options /
                 if (matchVal.groups.hex) {
                     if (matchVal.groups.hex !== matchVal.groups.hex.toLowerCase()) {
                         console.warn(
-                            `Warning: Only lowercase hex digits are accepted. No rules will be generated for \`${matchVal.groups.input}\``
+                            `Warning: Only lowercase hex digits are accepted. No rules will be generated for \`${matchVal.groups.hex}\``
                         );
                         value = null;
                     } else if (matchVal.groups.alpha) {


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

Fixing the warning that was missing the incorrect hex value.
