### PR TITLE
feat(atomizer): add calculatePercentage rule param

### DIFF
--- a/.changeset/twelve-walls-act.md
+++ b/.changeset/twelve-walls-act.md
@@ -1,0 +1,5 @@
+---
+'atomizer': minor
+---
+
+feat(atomizer): add allowFractions rule param

--- a/.changeset/twelve-walls-act.md
+++ b/.changeset/twelve-walls-act.md
@@ -2,4 +2,4 @@
 'atomizer': minor
 ---
 
-feat(atomizer): add allowFractions rule param
+feat(atomizer): add calculatePercentage rule param

--- a/docs/guides/custom-classes.md
+++ b/docs/guides/custom-classes.md
@@ -51,6 +51,28 @@ Atomizer will merge your custom class rules with the default rule set and produc
 
 The sections below explain each rule property available to configure. _(\*)denotes a required property._
 
+### allowFractions
+
+-   **Type**: `boolean`
+-   **Default**: `true`
+-   **Required**: `false`
+
+Allows Atomizer to calculate the quotient of a given fraction into a percentage (e.g. `W(1/2`) -> `W(50%)`). Some CSS properties like `aspect-ratio` will want to maintain the fraction and can disable the calculation by changing `allowFractions` to `false`.
+
+```json
+{
+    allowFractions: false,
+    matcher: 'Ar',
+    styles: {
+        'aspect-ratio': '$0',
+    },
+}
+```
+
+```html
+<div class="Ar(16/9)"></div>
+```
+
 ### allowParamToValue
 
 -   **Type**: `boolean`

--- a/docs/guides/custom-classes.md
+++ b/docs/guides/custom-classes.md
@@ -51,28 +51,6 @@ Atomizer will merge your custom class rules with the default rule set and produc
 
 The sections below explain each rule property available to configure. _(\*)denotes a required property._
 
-### allowFractions
-
--   **Type**: `boolean`
--   **Default**: `true`
--   **Required**: `false`
-
-Allows Atomizer to calculate the quotient of a given fraction into a percentage (e.g. `W(1/2`) -> `W(50%)`). Some CSS properties like `aspect-ratio` will want to maintain the fraction and can disable the calculation by changing `allowFractions` to `false`.
-
-```json
-{
-    allowFractions: false,
-    matcher: 'Ar',
-    styles: {
-        'aspect-ratio': '$0',
-    },
-}
-```
-
-```html
-<div class="Ar(16/9)"></div>
-```
-
 ### allowParamToValue
 
 -   **Type**: `boolean`
@@ -196,6 +174,28 @@ Will translate to `transform-origin: left bottom`.
 
 ```html
 <h1 class="H(20px)">Hello world!</h1>
+```
+
+### calculatePercentage
+
+-   **Type**: `boolean`
+-   **Default**: `true`
+-   **Required**: `false`
+
+Allows Atomizer to calculate the quotient of a given fraction into a percentage (e.g. `W(1/2`) -> `W(50%)`). Some CSS properties like `aspect-ratio` will want to maintain the fraction and can disable the calculation by changing `calculatePercentage` to `false`.
+
+```json
+{
+    calculatePercentage: false,
+    matcher: 'Ar',
+    styles: {
+        'aspect-ratio': '$0',
+    },
+}
+```
+
+```html
+<div class="Ar(16/9)"></div>
 ```
 
 ### description

--- a/packages/atomizer/src/atomizer.js
+++ b/packages/atomizer/src/atomizer.js
@@ -276,7 +276,7 @@ Atomizer.prototype.parseConfig = function (config /*:AtomizerConfig*/, options /
                         matchVal.groups.named = [matchVal.groups.number, matchVal.groups.unit].join('');
                     }
                 }
-                if (matchVal.groups.fraction && rule.allowFractions !== false) {
+                if (matchVal.groups.fraction && rule.calculatePercentage !== false) {
                     // multiplying by 100 then by 10000 on purpose (instead of just multiplying by 1M),
                     // making clear the steps involved:
                     // percentage: (numerator / denominator * 100)

--- a/packages/atomizer/src/atomizer.js
+++ b/packages/atomizer/src/atomizer.js
@@ -276,7 +276,7 @@ Atomizer.prototype.parseConfig = function (config /*:AtomizerConfig*/, options /
                         matchVal.groups.named = [matchVal.groups.number, matchVal.groups.unit].join('');
                     }
                 }
-                if (matchVal.groups.fraction) {
+                if (matchVal.groups.fraction && rule.allowFractions !== false) {
                     // multiplying by 100 then by 10000 on purpose (instead of just multiplying by 1M),
                     // making clear the steps involved:
                     // percentage: (numerator / denominator * 100)

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -216,7 +216,7 @@ module.exports = [
         type: 'pattern',
         name: 'Aspect ratio',
         matcher: 'Ar',
-        allowFractions: false,
+        calculatePercentage: false,
         allowParamToValue: false,
         styles: {
             'aspect-ratio': '$0',

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -216,6 +216,7 @@ module.exports = [
         type: 'pattern',
         name: 'Aspect ratio',
         matcher: 'Ar',
+        allowFractions: false,
         allowParamToValue: false,
         styles: {
             'aspect-ratio': '$0',

--- a/packages/atomizer/tests/atomizer.test.js
+++ b/packages/atomizer/tests/atomizer.test.js
@@ -583,9 +583,13 @@ describe('Atomizer()', () => {
                     'W(1/3)',
                     'Bgz(45px)',
                     'C(#FFF)',
+                    'Ar(16/9)',
                 ],
             };
             const expected = [
+                '.Ar\\(16\\/9\\) {',
+                '  aspect-ratio: 16/9;',
+                '}',
                 '.Bd\\(0\\) {',
                 '  border: 0;',
                 '}',


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

Adds a new rule option, `calculatePercentage`, to allow a rule to disable the automatic fraction calculation that Atomizer performs. Mainly needed for `aspect-ratio` to avoid calculating the ratio into a percentage.
