### PR TITLE
feat: add postcss-atomizer package

### DIFF
--- a/.changeset/young-walls-jam.md
+++ b/.changeset/young-walls-jam.md
@@ -1,0 +1,5 @@
+---
+'atomizer': minor
+---
+
+feat(atomizer): refactor binary to use build utils

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ vendor/bundle
 snippets.json
 *.vsix
 
-# webpack-atomizer-loader
+# example generated files
 **/example/*.css
 **/example/bundle.js
+# postcss requires this file for the demo
+!packages/postcss-atomizer/example/main.css

--- a/examples/atomizer.config.js
+++ b/examples/atomizer.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    content: ['./examples'],
+    content: ['./examples/*.html'],
     // 'custom' maps custom suffixes to values and it is specially useful for theming
     // or things that you need to change globally in many different atomic classes.
     // these key/value pairs map to the custom suffixes in 'classNames'.

--- a/packages/atomizer/bin/atomizer
+++ b/packages/atomizer/bin/atomizer
@@ -63,6 +63,16 @@ var filesToParse = program.args || [];
 // Add more src files from "content" property of config
 filesToParse = filesToParse.concat(findFiles(config.content));
 
+// Run atomizer build, output to stdout if css returned
+function runAtomizer(files, config = {}, options = {}, done) {
+    buildAtomicCss(files, config, options, function (err, css) {
+        done(err, css);
+        if (css) {
+            process.stdout.write(`\n${css}`);
+        }
+    });
+}
+
 // Used by the watcher to watch additional files
 function triggerBuild(state) {
     // Ensure only one build happens at a time.
@@ -73,7 +83,7 @@ function triggerBuild(state) {
     }
 
     state.building = true;
-    buildAtomicCss(Object.keys(state.files), config, programOpts, function (err) {
+    runAtomizer(Object.keys(state.files), config, programOpts, function (err) {
         if (err) {
             throw err;
         }
@@ -98,7 +108,7 @@ if (programOpts.watch === true || programOpts.watch.length) {
     // used for testing --watch input
     if (typeof process.env.TEST !== 'undefined') {
         console.log('Watching ' + chalk.cyan(filesToWatch.join(', ')) + ' for changes.');
-        buildAtomicCss(filesToParse, config, programOpts, function () {});
+        runAtomizer(filesToParse, config, programOpts, function () {});
     } else {
         var buildTriggerState = { files: {} };
         var watcher = chokidar.watch(filesToWatch);
@@ -116,5 +126,5 @@ if (programOpts.watch === true || programOpts.watch.length) {
         });
     }
 } else {
-    buildAtomicCss(filesToParse, config, programOpts, function () {});
+    runAtomizer(filesToParse, config, programOpts, function () {});
 }

--- a/packages/atomizer/bin/atomizer
+++ b/packages/atomizer/bin/atomizer
@@ -13,20 +13,9 @@ process.title = 'atomizer';
 var chalk = require('chalk');
 var chokidar = require('chokidar');
 var fs = require('fs');
-var glob = require('glob');
-var minimatch = require('minimatch');
-var path = require('path');
 var program = require('commander');
 var empty = require('lodash/isEmpty');
-var some = require('lodash/some');
-var union = require('lodash/union');
-var Atomizer = require('../src/atomizer');
-
-var content = '';
-var config = {};
-var classnames = [];
-var cwd = process.cwd();
-var defaultConfigPath = path.resolve(cwd, 'atomizer.config.js');
+var { buildAtomicCss, getConfig, findFiles } = require('../src/build');
 
 function collect(val, memo) {
     memo.push(val);
@@ -34,148 +23,33 @@ function collect(val, memo) {
 }
 
 program
-  .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
-  .usage('[options] [path]')
-  .option('-R, --recursive', 'process all files recursively in the path')
-  .option('-c, --config [file]', 'source config file')
-  .option('-r, --rules [file]', 'custom rules file (argument may be passed multiple times)', collect, [])
-  .option('-o, --outfile [file]', 'destination config file')
-  .option('-n, --namespace [namespace]', 'adds the given namespace to all generated Atomic CSS selectors')
-  .option('-H, --helpersNamespace [namespace]', 'adds the given namespace to all helper selectors')
-  .option('-w, --watch [target]', 'rebuilds when changes are detected in the file, directory, or glob (argument may be passed multiple times and are parsed for Atomic CSS classes)', collect, [])
-  .option('--exclude [pattern]', 'excluded file pattern', collect, [])
-  .option('--rtl', 'swaps `start` and `end` keyword replacements with `right` and `left`')
-  .option('--bump-mq', 'increases specificity of media queries a small amount')
-  .option('--ie', '[deprecated] no longer used')
-  .option('--verbose', 'show additional log info (warnings)')
-  .option('--quiet', 'hide processing info')
-  .parse(process.argv);
+    .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
+    .usage('[options] [path]')
+    .option('-R, --recursive', 'process all files recursively in the path')
+    .option('-c, --config [file]', 'source config file')
+    .option('-r, --rules [file]', 'custom rules file (argument may be passed multiple times)', collect, [])
+    .option('-o, --outfile [file]', 'destination config file')
+    .option('-n, --namespace [namespace]', 'adds the given namespace to all generated Atomic CSS selectors')
+    .option('-H, --helpersNamespace [namespace]', 'adds the given namespace to all helper selectors')
+    .option(
+        '-w, --watch [target]',
+        'rebuilds when changes are detected in the file, directory, or glob (argument may be passed multiple times and are parsed for Atomic CSS classes)',
+        collect,
+        []
+    )
+    .option('--exclude [pattern]', 'excluded file pattern', collect, [])
+    .option('--rtl', 'swaps `start` and `end` keyword replacements with `right` and `left`')
+    .option('--bump-mq', 'increases specificity of media queries a small amount')
+    .option('--ie', '[deprecated] no longer used')
+    .option('--verbose', 'show additional log info (warnings)')
+    .option('--quiet', 'hide processing info')
+    .parse(process.argv);
 
-function warn() {
-    if (!programOpts.quiet) console.warn.apply(console, arguments);
-}
-
-function parseFiles (files, recursive, dir) {
-    var classNames = [];
-
-    for (var i=0, iLen=files.length; i < iLen; i++) {
-        classNames = union(classNames, parseFile(files[i], recursive, dir));
-    }
-
-    return classNames;
-}
-
-function parseFile (file, recursive, dir) {
-    var classNames = [],
-        fileContents,
-        filepath,
-        relative,
-        stat;
-
-    if (file) {
-        filepath = dir ? path.resolve(dir, file) : path.resolve(file);
-        relative = path.relative(cwd, filepath);
-        stat = fs.statSync(filepath);
-
-        if (stat.isFile()) {
-            var isExcluded = false;
-            if (programOpts.exclude && programOpts.exclude.length) {
-              isExcluded = some(programOpts.exclude, function excludeFile(value) {
-                return minimatch(filepath, value, {matchBase: true});
-              });
-            }
-            if (!isExcluded) {
-              warn('Parsing file ' + chalk.cyan(relative) + ' for Atomic CSS classes');
-              fileContents = fs.readFileSync(filepath, {encoding: 'utf-8'});
-              classNames = atomizer.findClassNames(fileContents);
-            } else {
-              warn('Excluding file ' + chalk.cyan(relative) + ' for Atomic CSS classes');
-            }
-        } else if (stat.isDirectory()) {
-            if (!dir || dir && recursive) {
-                warn('Inspecting directory ' + chalk.cyan(path.relative(cwd, filepath)));
-                classNames = parseFiles(fs.readdirSync(filepath), recursive, filepath);
-            }
-        }
-    }
-    return classNames;
-}
-
-function buildAtomicCss(additionalFiles, done) {
-    // Add additional files, if any, from the watcher
-    var finalFilesToParse = additionalFiles.concat(filesToParse);
-    if (finalFilesToParse.length) {
-        classnames = parseFiles(finalFilesToParse, !!programOpts.recursive);
-    }
-
-    // Finalize the config
-    config = atomizer.getConfig(classnames, config);
-
-    // Create the CSS
-    content = atomizer.getCss(config, options);
-
-    // Output the CSS
-    var outfile = programOpts.outfile;
-    if (outfile) {
-        fs.readFile(outfile, {encoding: 'utf-8'}, function(err, data) {
-            if (data === content) {
-                console.log('Content of ' + chalk.cyan(outfile) + ' has not changed.');
-                done();
-            } else {
-                fs.mkdir(path.dirname(outfile), function (err) {
-                    // Fail silently
-                    fs.writeFile(path.resolve(outfile), content, function (err) {
-                        if (!err) {
-                            console.log('File ' + chalk.cyan(outfile) + ' created.');
-                        }
-                        done(err);
-                    });
-                });
-            }
-        });
-    } else {
-        process.stdout.write("\n" + content);
-        done();
-    }
-}
-
-function triggerBuild(state) {
-    // Ensure only one build happens at a time.
-    if (state.building) {
-        state.queued = true;
-
-        return;
-    }
-
-    state.building = true;
-    buildAtomicCss(Object.keys(state.files), function (err) {
-        if (err) {
-            throw err;
-        }
-        state.building = false;
-        if (state.queued) {
-            state.queued = false;
-            triggerBuild(state);
-        }
-    });
-}
-
-// Setup Atomizer instance
+// Gather cli arguments and options
 var programOpts = program.opts();
-var atomizer = new Atomizer({ verbose: !!programOpts.verbose });
 
-// Attempt to load config from `--config` option first, otherwise
-// check for a default config file in the current working directory
-var configFile = programOpts.config;
-if (configFile) {
-    if (!fs.existsSync(configFile)) {
-        console.error('Configuration file ' + chalk.cyan(configFile) + ' not found.');
-        return;
-    }
-    config = require(path.resolve(configFile));
-} else if (fs.existsSync(defaultConfigPath)) {
-    config = require(defaultConfigPath);
-}
+// Load the atomizer config file
+var config = getConfig(programOpts.config);
 
 // Print help menu if no config is loaded and no arguments are passed in
 if (empty(config) && process.argv.length <= 2) {
@@ -187,42 +61,28 @@ if (empty(config) && process.argv.length <= 2) {
 var filesToParse = program.args || [];
 
 // Add more src files from "content" property of config
-if (config.content && Array.isArray(config.content)) {
-    filesToParse = config.content
-        .reduce(function (files, pattern) {
-            var found = glob.sync(pattern, { matchBase: true });
-            return files.concat(found);
-        }, [])
-        .concat(filesToParse);
-}
+filesToParse = filesToParse.concat(findFiles(config.content));
 
-// Custom rulesets
-var rulesFiles = programOpts.rules;
-if (rulesFiles) {
-    rulesFiles.forEach(function (rulesFile) {
-        if (!fs.existsSync(rulesFile)) {
-            done(new Error('Rule file ' + chalk.cyan(rulesFile) + ' not found.'));
-            return false;
+// Used by the watcher to watch additional files
+function triggerBuild(state) {
+    // Ensure only one build happens at a time.
+    if (state.building) {
+        state.queued = true;
+
+        return;
+    }
+
+    state.building = true;
+    buildAtomicCss(Object.keys(state.files), config, programOpts, function (err) {
+        if (err) {
+            throw err;
         }
-        warn('Adding rules from ' + chalk.cyan(rulesFile) + '.');
-        atomizer.addRules(require(path.resolve(rulesFile)));
+        state.building = false;
+        if (state.queued) {
+            state.queued = false;
+            triggerBuild(state);
+        }
     });
-}
-
-// Options
-var options = {
-    rtl: programOpts.rtl,
-    bumpMQ: programOpts.bumpMq
-};
-
-// Options: Namespace
-if (typeof programOpts.namespace !== 'undefined') {
-    options.namespace = programOpts.namespace;
-}
-
-// Options: Helpers Namespace
-if (typeof programOpts.helpersNamespace !== 'undefined') {
-    options.helpersNamespace = programOpts.helpersNamespace;
 }
 
 // Setup Watcher
@@ -234,11 +94,11 @@ if (programOpts.watch === true || programOpts.watch.length) {
     if (Array.isArray(programOpts.watch) && programOpts.watch.length) {
         filesToWatch = filesToWatch.concat(programOpts.watch);
     }
-    
+
     // used for testing --watch input
     if (typeof process.env.TEST !== 'undefined') {
         console.log('Watching ' + chalk.cyan(filesToWatch.join(', ')) + ' for changes.');
-        buildAtomicCss([], function () {});
+        buildAtomicCss(filesToParse, config, programOpts, function () {});
     } else {
         var buildTriggerState = { files: {} };
         var watcher = chokidar.watch(filesToWatch);
@@ -256,6 +116,5 @@ if (programOpts.watch === true || programOpts.watch.length) {
         });
     }
 } else {
-    buildAtomicCss([], function () {});
+    buildAtomicCss(filesToParse, config, programOpts, function () {});
 }
-

--- a/packages/atomizer/index.d.ts
+++ b/packages/atomizer/index.d.ts
@@ -8,8 +8,6 @@ declare module 'atomizer' {
         exclude?: string;
         /** Adds the given namespace to all helper selectors */
         helpersNamespace?: string;
-        /** @deprecated */
-        ie?: boolean;
         /** Adds the given namespace to all generated Atomic CSS selectors */
         namespace?: string;
         /** Destination of CSS output file */
@@ -24,8 +22,6 @@ declare module 'atomizer' {
         rules?: string;
         /** Show additional log info (warnings) */
         verbose?: boolean;
-        /** Rebuilds when changes are detected in the file, directory, or glob */
-        watch?: string;
     }
 
     export interface AtomizerConfig {

--- a/packages/atomizer/index.d.ts
+++ b/packages/atomizer/index.d.ts
@@ -1,11 +1,46 @@
 declare module 'atomizer' {
+    export interface Options {
+        /** Increases specificity of media queries a small amount */
+        bumpMq?: boolean;
+        /** Source config file, defaults to "atomizer.config.js" */
+        config?: string;
+        /** Excluded file pattern */
+        exclude?: string;
+        /** Adds the given namespace to all helper selectors */
+        helpersNamespace?: string;
+        /** @deprecated */
+        ie?: boolean;
+        /** Adds the given namespace to all generated Atomic CSS selectors */
+        namespace?: string;
+        /** Destination of CSS output file */
+        outfile?: string;
+        /** Hide processing info */
+        quiet?: boolean;
+        /** Process all files recursively in the path */
+        recursive?: boolean;
+        /** Swaps `start` and `end` keyword replacements with `right` and `left` */
+        rtl?: boolean;
+        /** Path to custom rules file */
+        rules?: string;
+        /** Show additional log info (warnings) */
+        verbose?: boolean;
+        /** Rebuilds when changes are detected in the file, directory, or glob */
+        watch?: string;
+    }
+
     export interface AtomizerConfig {
-        custom?: Record<string, string | Record<string, string>>;
+        /** Custom media queries */
         breakPoints?: Record<string, string>;
+        /** List of allow listed Atomizer class names */
         classNames?: string[];
+        /** List of glob patterns paths to find parseable content */
+        content?: string[];
+        /** Custom CSS variables */
+        custom?: Record<string, string | Record<string, string>>;
     }
 
     export interface AtomizerOptions {
+        /** Show additional log info (warnings) */
         verbose?: boolean;
     }
 
@@ -13,14 +48,10 @@ declare module 'atomizer' {
         [key: string]: any;
     }
 
-    export interface CSSOptions {
+    export type CSSOptions = Pick<Options, 'banner' | 'bumpMq' | 'helpersNamespace' | 'namespace' | 'rtl'> & {
+        /** Adds a comment to the top of the generated Atomizer style sheet */
         banner?: string;
-        bumpMQ?: boolean;
-        helpersNamespace?: string;
-        ie?: boolean;
-        namespace?: string;
-        rtl?: boolean;
-    }
+    };
 
     export default class {
         public static escapeSelector: (str: string) => string;

--- a/packages/atomizer/index.d.ts
+++ b/packages/atomizer/index.d.ts
@@ -44,7 +44,7 @@ declare module 'atomizer' {
         [key: string]: any;
     }
 
-    export type CSSOptions = Pick<Options, 'banner' | 'bumpMq' | 'helpersNamespace' | 'namespace' | 'rtl'> & {
+    export type CSSOptions = Pick<Options, 'bumpMq' | 'helpersNamespace' | 'namespace' | 'rtl'> & {
         /** Adds a comment to the top of the generated Atomizer style sheet */
         banner?: string;
     };

--- a/packages/atomizer/src/atomizer.js
+++ b/packages/atomizer/src/atomizer.js
@@ -23,9 +23,11 @@ const GLOBAL_VALUES = {
 };
 
 /**
- * constructor
+ * @constructor
+ * @param {import('atomizer').AtomizerOptions} options Atomizer options
+ * @param {Array<import('atomizer').AtomizerRule>} [rules] List of custom rules
  */
-function Atomizer(options /*:AtomizerOptions*/, rules /*:AtomizerRules*/) {
+function Atomizer(options, rules) {
     this.verbose = (options && options.verbose) || false;
     this.rules = [];
     // we have two different objects to avoid name collision
@@ -37,10 +39,12 @@ function Atomizer(options /*:AtomizerOptions*/, rules /*:AtomizerRules*/) {
 }
 
 /**
- * addRules
+ * Add custom rules to Atomizer
+ * @param {Array<import('atomizer').AtomizerRule>} rules List of custom rules
+ * @return {void}
  * @public
  */
-Atomizer.prototype.addRules = function (rules /*:AtomizerRules*/) /*:void*/ {
+Atomizer.prototype.addRules = function (rules) {
     rules.forEach((rule) => {
         const ruleFound = rule.type === 'pattern' && Object.prototype.hasOwnProperty.call(this.rulesMap, rule.matcher);
         const helperFound =
@@ -71,7 +75,9 @@ Atomizer.prototype.addRules = function (rules /*:AtomizerRules*/) /*:void*/ {
 };
 
 /**
- * getClassNameSyntax()
+ * Returns class name syntax
+ * @param {boolean} [isSimple] Whether to return the simple syntax
+ * @return {string} Class name syntax
  * @private
  */
 Atomizer.prototype.getSyntax = function (isSimple) /*:string*/ {
@@ -87,9 +93,11 @@ Atomizer.prototype.getSyntax = function (isSimple) /*:string*/ {
 };
 
 /**
- * findClassNames
+ * Given a string find CSS class names
+ * @param {string} src String to parse
+ * @return {string[]} List of class names
  */
-Atomizer.prototype.findClassNames = function (src /*:string*/) /*:string[]*/ {
+Atomizer.prototype.findClassNames = function (src) {
     // using object to remove dupes
     const classNamesObj = {};
     let className;
@@ -114,28 +122,28 @@ Atomizer.prototype.findClassNames = function (src /*:string*/) /*:string[]*/ {
 
 /**
  * Get Atomizer config given an array of class names and an optional config object
- * examples:
  *
- * getConfig(['Op(1)', 'D(n):h', 'Fz(heading)'], {
- *     custom: {
- *         heading: '80px'
- *     },
- *     breakPoints: {
- *         'sm': '@media(min-width:500px)',
- *         'md': '@media(min-width:900px)',
- *         'lg': '@media(min-width:1200px)'
- *     },
- *     classNames: ['D(b)']
- * }, {
- *     rtl: true
- * });
+ * @example
+ *     getConfig(['Op(1)', 'D(n):h', 'Fz(heading)'], {
+ *         custom: {
+ *             heading: '80px'
+ *         },
+ *         breakPoints: {
+ *             sm: '@media(min-width:500px)',
+ *             md: '@media(min-width:900px)',
+ *             lg: '@media(min-width:1200px)'
+ *         },
+ *         classNames: ['D(b)']
+ *     });
  *
- * getConfig(['Op(1)', 'D(n):h']);
+ * @example
+ *     getConfig(['Op(1)', 'D(n):h']);
+ *
+ * @param {string[]} [classNames] List of Atomizer class names
+ * @param {import('atomizer').AtomizerConfig} [existingConfig] Existing Atomizer config
+ * @return {import('atomizer').AtomizerConfig} Final Atomizer config
  */
-Atomizer.prototype.getConfig = function (
-    classNames /*:string[]*/,
-    existingConfig /*:AtomizerConfig*/
-) /*:AtomizerConfig*/ {
+Atomizer.prototype.getConfig = function (classNames, existingConfig) {
     const config = (existingConfig && _.cloneDeep(existingConfig)) || { classNames: [] };
     // merge classnames with config
     config.classNames = this.sortCSS(_.union(classNames || [], config.classNames));
@@ -143,9 +151,11 @@ Atomizer.prototype.getConfig = function (
 };
 
 /**
- * return sorted rule
+ * Return sorted rule
+ * @param {string[]} classNames List of classes to sort
+ * @return {string[]} List of sorted classes
  */
-Atomizer.prototype.sortCSS = function (classNames /*string[]*/) {
+Atomizer.prototype.sortCSS = function (classNames) {
     // 1. sort by alphabetical order
     classNames = classNames.sort();
 
@@ -175,9 +185,12 @@ Atomizer.prototype.sortCSS = function (classNames /*string[]*/) {
 };
 
 /**
- * return a parsed tree given a config and css options
+ * Return a parsed tree given a config and css options
+ * @param {import('atomizer').AtomizerConfig} config
+ * @param {import('atomizer').CSSOptions} options
+ * @return {object} Final CSS tree structure
  */
-Atomizer.prototype.parseConfig = function (config /*:AtomizerConfig*/, options /*:CSSOptions*/) /*:Tree*/ {
+Atomizer.prototype.parseConfig = function (config, options) {
     const tree = {};
     const classNameSyntax = this.getSyntax(true);
     const warnings = [];
@@ -445,25 +458,28 @@ Atomizer.prototype.parseConfig = function (config /*:AtomizerConfig*/, options /
 
 /**
  * Get CSS given an array of class names, a config and css options.
- * examples:
  *
- * getCss({
- *     custom: {
- *         heading: '80px'
- *     },
- *     breakPoints: {
- *         'sm': '@media(min-width:500px)',
- *         'md': '@media(min-width:900px)',
- *         'lg': '@media(min-width:1200px)'
- *     },
- *     classNames: ['D(b)', 'Op(1)', 'D(n):h', 'Fz(heading)']
- * }, {
- *     rtl: true
- * });
+ * @example
+ *     getCss({
+ *         custom: {
+ *             heading: '80px'
+ *         },
+ *         breakPoints: {
+ *             sm: '@media(min-width:500px)',
+ *             md: '@media(min-width:900px)',
+ *             lg: '@media(min-width:1200px)'
+ *         },
+ *         classNames: ['D(b)', 'Op(1)', 'D(n):h', 'Fz(heading)']
+ *     }, {
+ *         rtl: true
+ *     });
  *
+ * @param {import('atomizer').AtomizerConfig} config Atomizer config
+ * @param {import('atomizer').CSSOptions} options CSS options
+ * @return {string} Final atomizer CSS
  * @public
  */
-Atomizer.prototype.getCss = function (config /*:AtomizerConfig*/, options /*:CSSOptions*/) /*:string*/ {
+Atomizer.prototype.getCss = function (config, options) {
     const jss = {};
     let content = '';
     let breakPoints;
@@ -593,9 +609,12 @@ Atomizer.prototype.getCss = function (config /*:AtomizerConfig*/, options /*:CSS
 
 /**
  * Escape CSS selectors with a backslash
- * e.g. ".W-100%" => ".W-100\%"
+ * @example
+ *     ".W-100%" => ".W-100\%"
+ * @param {string} str String to parse
+ * @return {string} String with escaped selectors
  */
-Atomizer.escapeSelector = function (str /*:string*/) /*:string*/ {
+Atomizer.escapeSelector = function (str) {
     if (!str && str !== 0) {
         throw new TypeError('str must be present');
     }
@@ -621,6 +640,9 @@ Atomizer.escapeSelector = function (str /*:string*/) /*:string*/ {
 
 /**
  * Replace LTR/RTL placeholders with actual left/right strings
+ * @param {string} str String to parse
+ * @param {boolean} [rtl] Whether to replace with RTL
+ * @return {string} Replaced string
  */
 Atomizer.replaceConstants = function (str /*:string*/, rtl /*:boolean*/) {
     const start = rtl ? 'right' : 'left';

--- a/packages/atomizer/src/build.js
+++ b/packages/atomizer/src/build.js
@@ -1,0 +1,201 @@
+const chalk = require('chalk');
+const fs = require('fs');
+const glob = require('glob');
+const minimatch = require('minimatch');
+const path = require('path');
+const some = require('lodash/some');
+const union = require('lodash/union');
+
+const cwd = process.cwd();
+const defaultConfigPath = path.resolve(cwd, 'atomizer.config.js');
+const Atomizer = require('./atomizer');
+
+// stub for now and let buildAtomicCss implement based on passed in options
+let warn = function () {};
+
+/**
+ * Parses and expands an array of file glob patterns
+ * @param {string[]} content Array of glob patterns to parse
+ * @returns {string[]} Array of file paths
+ */
+module.exports.findFiles = function (content) {
+    if (content && Array.isArray(content)) {
+        return content.reduce(function (files, pattern) {
+            const found = glob.sync(pattern, { matchBase: true });
+            return files.concat(found);
+        }, []);
+    }
+    return [];
+};
+
+/**
+ * Returns the config object for a given config file path. If not found,
+ * returns the default config from cwd() + 'atomizer.config.js'
+ * @param {string} configFile
+ * @returns {import('atomizer').AtomizerConfig} The resolved atomizer config object
+ */
+module.exports.getConfig = function (configFile) {
+    let config = {};
+    if (configFile) {
+        if (!fs.existsSync(configFile)) {
+            console.error(`Configuration file ${chalk.cyan(configFile)} not found.`);
+            return config;
+        }
+        config = require(path.resolve(configFile));
+    } else if (fs.existsSync(defaultConfigPath)) {
+        config = require(defaultConfigPath);
+    }
+    return config;
+};
+
+/**
+ * Executes Atomizer on a given set of files, creating an atomic CSS file (if provided) or outputting to stdout
+ * @param {string[]} files List of files to parse
+ * @param {import('atomizer').AtomizerConfig} config Atomizer config object
+ * @param {import('atomizer').Options} [options] Additional options
+ * @param {Function} [done] Optional callback function
+ */
+module.exports.buildAtomicCss = function (files, config = {}, options = {}, done) {
+    const cssOptions = {
+        rtl: options.rtl,
+        bumpMQ: options.bumpMq,
+    };
+
+    // Options: Namespace
+    if (typeof options.namespace !== 'undefined') {
+        cssOptions.namespace = options.namespace;
+    }
+
+    // Options: Helpers Namespace
+    if (typeof options.helpersNamespace !== 'undefined') {
+        cssOptions.helpersNamespace = options.helpersNamespace;
+    }
+
+    // By default, warn users unless quite is set to true
+    if (!options.quiet) {
+        warn = function (...args) {
+            console.warn.apply(console, args);
+        };
+    }
+
+    // Instantiate Atomizer
+    const atomizer = new Atomizer({ verbose: !!options.verbose });
+
+    // Custom rulesets
+    const rulesFiles = options.rules;
+    if (rulesFiles) {
+        rulesFiles.forEach(function (rulesFile) {
+            if (!fs.existsSync(rulesFile)) {
+                console.log(`Rule file ${chalk.cyan(rulesFile)} not found.`);
+                return false;
+            }
+            warn(`Adding rules from ${chalk.cyan(rulesFile)}.`);
+            atomizer.addRules(require(path.resolve(rulesFile)));
+        });
+    }
+
+    // Add additional files, if any, from the watcher
+    const classnames = parseFiles({ files, recursive: !!options.recursive, exclude: options.exclude, atomizer });
+
+    // Finalize the config
+    config = atomizer.getConfig(classnames, config);
+
+    // Create the CSS
+    const content = atomizer.getCss(config, cssOptions);
+
+    // Output the CSS
+    const { outfile } = options;
+    if (outfile) {
+        fs.readFile(outfile, { encoding: 'utf-8' }, function (err, data) {
+            if (data === content) {
+                console.log(`Content of ${chalk.cyan(outfile)} has not changed.`);
+                done && done();
+            } else {
+                fs.mkdir(path.dirname(outfile), function () {
+                    // Fail silently
+                    fs.writeFile(path.resolve(outfile), content, function (err) {
+                        if (!err) {
+                            console.log(`File ${chalk.cyan(outfile)} created.`);
+                        }
+                        done && done(err);
+                    });
+                });
+            }
+        });
+    } else {
+        process.stdout.write(`\n${content}`);
+        done && done();
+    }
+};
+
+/**
+ * Give an array of files, parse atomizer classes
+ * @param {object} params Options object
+ * @param {string[]} params.files List of files paths to parse
+ * @param {boolean} [params.recursive] Whether to parse files recursively
+ * @param {string} [params.dir] The directory to parse files from
+ * @param {string[]} [params.exclude] List of files to exclude
+ * @param {import('atomizer').default} params.atomizer The atomizer instance
+ * @returns {Array} List of atomizer classes
+ */
+function parseFiles({ files, recursive, dir, exclude, atomizer }) {
+    let classNames = [];
+
+    for (let i = 0, iLen = files.length; i < iLen; i++) {
+        classNames = union(classNames, parseFile({ file: files[i], recursive, dir, exclude, atomizer }));
+    }
+
+    return classNames;
+}
+
+/**
+ * Give an array of files, parse atomizer classes
+ * @param {object} params Options object
+ * @param {string} params.file The file path to parse
+ * @param {boolean} [params.recursive] Whether to parse files recursively
+ * @param {string} [params.dir] The directory to parse files from
+ * @param {string[]} [params.exclude] List of files to exclude
+ * @param {import('atomizer').default} params.atomizer The atomizer instance
+ * @returns {Array} List of atomizer classes
+ */
+function parseFile({ file, recursive, dir, exclude, atomizer }) {
+    let classNames = [],
+        fileContents,
+        filepath,
+        relative,
+        stat;
+
+    if (file) {
+        filepath = dir ? path.resolve(dir, file) : path.resolve(file);
+        relative = path.relative(cwd, filepath);
+        stat = fs.statSync(filepath);
+
+        if (stat.isFile()) {
+            let isExcluded = false;
+            if (exclude && exclude.length) {
+                isExcluded = some(exclude, function excludeFile(value) {
+                    return minimatch(filepath, value, { matchBase: true });
+                });
+            }
+            if (!isExcluded) {
+                warn(`Parsing file ${chalk.cyan(relative)} for Atomic CSS classes`);
+                fileContents = fs.readFileSync(filepath, { encoding: 'utf-8' });
+                classNames = atomizer.findClassNames(fileContents);
+            } else {
+                warn(`Excluding file ${chalk.cyan(relative)} for Atomic CSS classes`);
+            }
+        } else if (stat.isDirectory()) {
+            if (!dir || (dir && recursive)) {
+                warn(`Inspecting directory ${chalk.cyan(path.relative(cwd, filepath))}`);
+                classNames = parseFiles({
+                    files: fs.readdirSync(filepath),
+                    recursive,
+                    dir: filepath,
+                    exclude,
+                    atomizer,
+                });
+            }
+        }
+    }
+    return classNames;
+}

--- a/packages/atomizer/src/build.js
+++ b/packages/atomizer/src/build.js
@@ -49,11 +49,12 @@ module.exports.getConfig = function (configFile) {
 };
 
 /**
- * Executes Atomizer on a given set of files, creating an atomic CSS file (if provided) or outputting to stdout
+ * Executes Atomizer on a given set of files, creating an atomic CSS file (if provided) or returning the atomic CSS as a string
  * @param {string[]} files List of files to parse
  * @param {import('atomizer').AtomizerConfig} config Atomizer config object
  * @param {import('atomizer').Options} [options] Additional options
- * @param {Function} [done] Optional callback function
+ * @param {function} [done] Optional callback function
+ * @return {string} Atomic CSS if no output file is provided
  */
 module.exports.buildAtomicCss = function (files, config = {}, options = {}, done) {
     const cssOptions = {
@@ -103,7 +104,7 @@ module.exports.buildAtomicCss = function (files, config = {}, options = {}, done
     // Create the CSS
     const content = atomizer.getCss(config, cssOptions);
 
-    // Output the CSS
+    // Output the CSS to a file, otherwise return CSS content
     const { outfile } = options;
     if (outfile) {
         fs.readFile(outfile, { encoding: 'utf-8' }, function (err, data) {
@@ -115,7 +116,7 @@ module.exports.buildAtomicCss = function (files, config = {}, options = {}, done
                     // Fail silently
                     fs.writeFile(path.resolve(outfile), content, function (err) {
                         if (!err) {
-                            console.log(`File ${chalk.cyan(outfile)} created.`);
+                            console.log(`File ${chalk.cyan(outfile)} updated.`);
                         }
                         done && done(err);
                     });
@@ -123,8 +124,10 @@ module.exports.buildAtomicCss = function (files, config = {}, options = {}, done
             }
         });
     } else {
-        process.stdout.write(`\n${content}`);
-        done && done();
+        if (done) {
+            return done(null, content);
+        }
+        return content;
     }
 };
 

--- a/packages/atomizer/tests/bin/atomizer.test.js
+++ b/packages/atomizer/tests/bin/atomizer.test.js
@@ -44,7 +44,7 @@ describe('atomizer', () => {
 
         it('--exclude', async () => {
             const { stdout } = await execFileAsync('node', [atomizer, htmlFixture, '--exclude', 'test.html']);
-            expect(stdout).toEqual('\n'); // exluding the default file should result in an empty output
+            expect(stdout).toEqual(''); // exluding the default file should result in an empty output
         });
 
         it('--helpersNamespace', async () => {

--- a/packages/postcss-atomizer/CHANGELOG.md
+++ b/packages/postcss-atomizer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# postcss-atomizer
+
+## 1.0.0
+
+### Major Changes
+
+-   init files

--- a/packages/postcss-atomizer/README.md
+++ b/packages/postcss-atomizer/README.md
@@ -1,0 +1,42 @@
+# postcss-atomizer
+
+[PostCSS](https://postcss.org/) plugin for Atomizer.
+
+## Installation
+
+```shell
+npm i postcss-atomizer postcss -D
+```
+
+## Usage
+
+Update your project's `postcss.config.js` file by adding the atomizer plugin:
+
+```js
+// postcss.config.js
+const atomizerPlugin = require('postcss-atomizer');
+
+module.exports = {
+    plugins: [
+        atomizerPlugin({ /* options */ }),
+    ]
+};
+```
+
+The plugin will automatically execute Atomizer based on your project's [`atomizer.config.js`](https://acss.io/configuration.html) file and pass the rendered CSS to any additional plugins you configure.
+
+### Options
+
+The available options follow the [`Options` interface](https://github.com/acss-io/atomizer/blob/main/packages/atomizer/index.d.ts) from Atomizer's TypeScript definition.
+
+By default, the plugin will look for an `atomizer.config.js` file at the root of your project. If your config file is in another location, you use the `config` property to specify it:
+
+```js
+module.exports = {
+    plugins: [
+        atomizerPlugin({
+            config: `${process.cwd()}/path/to/atomizer.config.js`
+        }),
+    ]
+};
+```

--- a/packages/postcss-atomizer/example/README.md
+++ b/packages/postcss-atomizer/example/README.md
@@ -1,0 +1,18 @@
+# postcss-atomizer
+
+## Run the example
+
+Assuming you installed the dependencies at the root of the repository, you can generate the CSS via the following run script:
+
+```shell
+npm run dev
+```
+
+Open the `index.html` file in your browser to see the rendered page.
+
+## Files
+
+-   `atomizer.config.js` - Contains Atomizer configuration
+-   `index.html` - HTML page to render
+-   `main.css` - Sample CSS file for postcss to process
+-   `postcss.config.js` - PostCSS configuration file that configures postcss-atomizer

--- a/packages/postcss-atomizer/example/__tests__/__snapshots__/postcss.test.js.snap
+++ b/packages/postcss-atomizer/example/__tests__/__snapshots__/postcss.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postcss should create post css 1`] = `
+"/* dummy test */.Bdrs\\(\\.5rem\\) {
+  border-radius: .5rem;
+}.Bgc\\(backgroundColor\\) {
+  background-color: #333;
+}.C\\(textColor\\) {
+  color: #fff;
+}.Ff\\(ss\\) {
+  font-family: Helvetica, Arial, sans-serif;
+}.Fw\\(b\\) {
+  font-weight: bold;
+}.Fz\\(2rem\\) {
+  font-size: 2rem;
+}.Lh\\(1\\.5\\) {
+  line-height: 1.5;
+}.Mx\\(a\\) {
+  margin-left: auto;
+  margin-right: auto;
+}.Px\\(1rem\\) {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}.Py\\(\\.1rem\\) {
+  padding-top: .1rem;
+  padding-bottom: .1rem;
+}.W\\(35vw\\) {
+  width: 35vw;
+}"
+`;

--- a/packages/postcss-atomizer/example/__tests__/postcss.test.js
+++ b/packages/postcss-atomizer/example/__tests__/postcss.test.js
@@ -1,0 +1,17 @@
+const postcss = require('postcss');
+const atomizerPlugin = require('postcss-atomizer');
+const { join } = require('path');
+
+describe('postcss', () => {
+    it('should create post css', async () => {
+        const input = '/* dummy test */';
+        const output = '';
+        const atomizer = atomizerPlugin({
+            config: join(__dirname, '..', 'atomizer.config.js'),
+        });
+        const result = await postcss([atomizer]).process(input, { from: undefined });
+
+        expect(result.css).toMatchSnapshot(output);
+        expect(result.warnings()).toHaveLength(0);
+    });
+});

--- a/packages/postcss-atomizer/example/atomizer.config.js
+++ b/packages/postcss-atomizer/example/atomizer.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    content: ['index.html'],
+    custom: {
+        backgroundColor: '#333',
+        textColor: '#fff',
+    },
+};

--- a/packages/postcss-atomizer/example/index.html
+++ b/packages/postcss-atomizer/example/index.html
@@ -3,15 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Atomizer - Webpack</title>
+        <title>Atomizer - PostCSS</title>
         <link rel="stylesheet" href="dist/main.css" />
     </head>
     <body>
         <main class="Bgc(backgroundColor) C(textColor) W(35vw) Px(1rem) Py(.1rem) Ff(ss) Mx(a) Bdrs(.5rem)">
             <h1 class="Fw(b) Fz(2rem)">Atomizer PostCSS Plugin</h1>
-            <p class="Lh(1.5)">
-                This simple example show's how to configure webpack parse JS to generate a "atomizer.css" file.
-            </p>
+            <p class="Lh(1.5)">This simple example show's how to configure Atomizer with PostCSS.</p>
         </main>
     </body>
 </html>

--- a/packages/postcss-atomizer/example/index.html
+++ b/packages/postcss-atomizer/example/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Atomizer - Webpack</title>
+        <link rel="stylesheet" href="dist/main.css" />
+    </head>
+    <body>
+        <main class="Bgc(backgroundColor) C(textColor) W(35vw) Px(1rem) Py(.1rem) Ff(ss) Mx(a) Bdrs(.5rem)">
+            <h1 class="Fw(b) Fz(2rem)">Atomizer PostCSS Plugin</h1>
+            <p class="Lh(1.5)">
+                This simple example show's how to configure webpack parse JS to generate a "atomizer.css" file.
+            </p>
+        </main>
+    </body>
+</html>

--- a/packages/postcss-atomizer/example/main.css
+++ b/packages/postcss-atomizer/example/main.css
@@ -1,0 +1,1 @@
+/* Stub css file for postcss */

--- a/packages/postcss-atomizer/example/package.json
+++ b/packages/postcss-atomizer/example/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "postcss-atomizer-example",
+    "private": true,
+    "scripts": {
+        "dev": "postcss *.css -o dist/main.css"
+    }
+}

--- a/packages/postcss-atomizer/example/postcss.config.js
+++ b/packages/postcss-atomizer/example/postcss.config.js
@@ -1,0 +1,7 @@
+const atomizerPlugin = require('postcss-atomizer');
+
+const atomizer = atomizerPlugin();
+
+module.exports = {
+    plugins: [atomizer],
+};

--- a/packages/postcss-atomizer/package.json
+++ b/packages/postcss-atomizer/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "postcss-atomizer",
+    "version": "1.0.0",
+    "description": "PostCSS Atomizer plugin",
+    "keywords": [
+        "atomizer",
+        "postcss-plugin"
+    ],
+    "homepage": "https://github.com/acss-io/atomizer#readme",
+    "bugs": {
+        "url": "https://github.com/acss-io/atomizer/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/acss-io/atomizer.git",
+        "directory": "packages/postcss-atomizer"
+    },
+    "license": "BSD-3-Clause",
+    "author": "Seth Bertalotto <seth@bertalotto.net>",
+    "exports": "./src/index.js",
+    "files": [
+        "src"
+    ],
+    "scripts": {
+        "test": "jest ."
+    },
+    "dependencies": {
+        "atomizer": "^3.18.2"
+    },
+    "peerDependencies": {
+        "postcss": "^8.3.0"
+    },
+    "engines": {
+        "node": ">=16.0",
+        "npm": ">=8.0"
+    }
+}

--- a/packages/postcss-atomizer/src/index.js
+++ b/packages/postcss-atomizer/src/index.js
@@ -1,0 +1,17 @@
+const { buildAtomicCss, getConfig, findFiles } = require('atomizer/src/build.js');
+
+/**
+ * @type {import('postcss').PluginCreator}
+ */
+module.exports = (options = {}) => {
+    const config = getConfig(options.config);
+    const files = findFiles(config.content);
+    return {
+        postcssPlugin: 'postcss-atomizer',
+        Root(root) {
+            root.append(buildAtomicCss(files, config, options));
+        },
+    };
+};
+
+module.exports.postcss = true;


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

Added a new package, `postcss-atomizer` to the project to make it easier to integrate with PostCSS.

### Motivation and Context

Many projects use PostCSS (even our docs site) to modify their CSS by adding vendor prefixes, minifying, supporting new browser features, and a ton of other things. Using Atomizer outside of this flow is awkward since you have to run it first and then take its output as input into PostCSS. 

This new plugin makes it much easier to integrate with PostCSS. The package Readme shows the configuration and I added a working example to verify that it works.

### Changes

I had to modify the Atomizer binary file to extract out how files are parsed and executed. Since much of that same logic was needed for the plugin, it was easier to refactor the useful bits into reusable functions. 

So now the plugin and the binary use the same utility functions to execute Atomizer. The exist binary tests still pass so I was able to verify that there were no regressions.

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Review the following points, and put an x in all the boxes that apply. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help!

-   [ ] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/acss-io/atomizer/blob/main/CONTRIBUTING.md) document.
-   [x] I have added tests to cover my changes.
