### PR TITLE
feat(plugin): support dual module publish (cjs and mjs)

### DIFF
--- a/.changeset/honest-steaks-trade.md
+++ b/.changeset/honest-steaks-trade.md
@@ -1,0 +1,5 @@
+---
+'atomizer-plugins': minor
+---
+
+support dual module publish (cjs and mjs)

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,7 @@ bin
 artifacts
 node_nodules
 dist
+dist-*
 
 # docs
 docs/assets/js/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # build files
 dist/
+dist-*/
 examples/css/atomic.css
 *.tsbuildinfo
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 build/
 coverage/
 dist/
+dist-*/
 node_modules/
 vendor/
 

--- a/docs/integrations/esbuild.md
+++ b/docs/integrations/esbuild.md
@@ -36,7 +36,7 @@ import { esbuild } from 'atomizer-plugins';
 const atomizer = esbuild({
     /* options */
     config: atomizerConfig,
-    outputFile: 'dist/atomizer.css',
+    outfile: 'dist/atomizer.css',
 });
 
 build({

--- a/docs/integrations/rollup.md
+++ b/docs/integrations/rollup.md
@@ -35,7 +35,7 @@ import { rollup } from 'atomizer-plugins';
 const atomizer = rollup({
     /* options */
     config: atomizerConfig,
-    outputFile: 'dist/atomizer.css',
+    outfile: 'dist/atomizer.css',
 });
 
 export default {

--- a/docs/integrations/solidjs.md
+++ b/docs/integrations/solidjs.md
@@ -46,7 +46,7 @@ import atomizerConfig from './atomizer.config.js';
 
 const atomizerPlugin = vite({
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
+    outfile: 'atomizer.css',
 });
 
 export default defineConfig({

--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -49,7 +49,7 @@ import atomizerConfig from './atomizer.config.js';
 
 const atomizerPlugin = vite({
     config: atomizerConfig,
-    outputFile: 'dist/atomizer.css',
+    outfile: 'dist/atomizer.css',
 });
 
 export default defineConfig(() => {

--- a/docs/integrations/webpack.md
+++ b/docs/integrations/webpack.md
@@ -67,7 +67,7 @@ import { webpack } from 'atomizer-plugins';
 const atomizer = webpack({
     /* options */
     config: atomizerConfig,
-    outputFile: 'dist/atomizer.css',
+    outfile: 'dist/atomizer.css',
 });
 
 export default {

--- a/packages/atomizer-plugins/README.md
+++ b/packages/atomizer-plugins/README.md
@@ -26,7 +26,6 @@ import { esbuild } from 'atomizer-plugins';
 const atomizer = rollup({
     /* options */
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
 });
 
 build({
@@ -44,7 +43,6 @@ import { rollup } from 'atomizer-plugins';
 const atomizer = rollup({
     /* options */
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
 });
 
 export default {
@@ -61,7 +59,6 @@ import { vite } from 'atomizer-plugins';
 
 const atomizerPlugin = vite({
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
 });
 
 export default defineConfig(() => {
@@ -80,7 +77,6 @@ import { webpack } from 'atomizer-plugins';
 const atomizer = webpack({
     /* options */
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
 });
 
 export default {

--- a/packages/atomizer-plugins/examples/rollup/rollup.config.mjs
+++ b/packages/atomizer-plugins/examples/rollup/rollup.config.mjs
@@ -7,7 +7,6 @@ const __dirname = getDirname(import.meta.url);
 
 const atomizer = rollup({
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
 });
 
 export default {

--- a/packages/atomizer-plugins/examples/vite/vite.config.mjs
+++ b/packages/atomizer-plugins/examples/vite/vite.config.mjs
@@ -4,7 +4,6 @@ import atomizerConfig from '../atomizer.config.mjs';
 
 const atomizerPlugin = vite({
     config: atomizerConfig,
-    outputFile: 'atomizer.css',
 });
 
 export default defineConfig(() => {

--- a/packages/atomizer-plugins/examples/webpack/webpack.config.mjs
+++ b/packages/atomizer-plugins/examples/webpack/webpack.config.mjs
@@ -7,7 +7,7 @@ const __dirname = getDirname(import.meta.url);
 
 const atomizer = webpack({
     config: atomizerConfig,
-    outputFile: './dist/atomizer.css',
+    outfile: './dist/atomizer.css',
 });
 
 export default {

--- a/packages/atomizer-plugins/package.json
+++ b/packages/atomizer-plugins/package.json
@@ -24,14 +24,21 @@
     },
     "license": "BSD-3-Clause",
     "author": "Seth Bertalotto <seth@bertalotto.net>",
-    "type": "module",
-    "exports": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./dist-cjs/index.js",
+    "exports": {
+        "import": "./dist-mjs/index.mjs",
+        "require": "./dist-cjs/index.js"
+    },
+    "types": "./dist-mjs/index.d.ts",
     "files": [
-        "dist"
+        "dist-cjs",
+        "dist-mjs"
     ],
     "scripts": {
-        "build": "tsc -p tsconfig.json",
+        "build": "npm run build:cjs && npm run build:mjs",
+        "build:cjs": "tsc -p tsconfig.cjs.json",
+        "build:mjs": "tsc -p tsconfig.mjs.json",
+        "postbuild": "for file in dist-mjs/*.js; do mv -- \"$file\" \"${file%.js}.mjs\"; done",
         "test": "node --experimental-vm-modules ../../node_modules/.bin/jest -c ../../jest.config.js examples/"
     },
     "dependencies": {

--- a/packages/atomizer-plugins/src/index.ts
+++ b/packages/atomizer-plugins/src/index.ts
@@ -28,7 +28,7 @@ export const unplugin = createUnplugin<Options>((options) => {
             this.emitFile({
                 type: 'asset',
                 source: css,
-                fileName: options.outputFile || 'atomizer.css',
+                fileName: options.outfile || 'atomizer.css',
             });
         },
     };

--- a/packages/atomizer-plugins/src/types.ts
+++ b/packages/atomizer-plugins/src/types.ts
@@ -5,6 +5,6 @@ export interface Options extends AtomizerOptions {
     cssOptions?: CSSOptions;
     /* Atomizer config options */
     config: AtomizerConfig;
-    /* Output file name, relative to cwd */
-    outputFile?: string;
+    /* Output file name, relative to cwd. Defaults to atomizer.css */
+    outfile?: string;
 }

--- a/packages/atomizer-plugins/tsconfig.cjs.json
+++ b/packages/atomizer-plugins/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "outDir": "dist-cjs",
+        "module": "commonjs",
+        "rootDir": "src"
+    },
+    "include": ["src"]
+}

--- a/packages/atomizer-plugins/tsconfig.mjs.json
+++ b/packages/atomizer-plugins/tsconfig.mjs.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "baseUrl": ".",
-        "outDir": "dist",
+        "outDir": "dist-mjs",
         "rootDir": "src"
     },
     "include": ["src"]


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

To make it easier to integrated on older and new code bases, this package will now publish cjs and mjs versions. 

I also changed `outputFile` to `outfile` to match the Atomizer library convention.