### PR TITLE
feat(docs): add copy button to code blocks

### DIFF
--- a/app/assets/css/colors.css
+++ b/app/assets/css/colors.css
@@ -5,6 +5,7 @@
     --color-code-bd: #e5e7eb;
     --color-emphasis: #000000;
     --color-headers: #4c4c4c;
+    --color-success: #3fb950;
     --color-text: #4c4c4c;
 
     /* ui elements */

--- a/app/assets/css/custom.css
+++ b/app/assets/css/custom.css
@@ -193,12 +193,19 @@ li.selected a {
 #main h2:hover .octicon,
 #main h3:hover .octicon {
     display: inline-block;
-    fill: currentColor;
 }
 .octicon-link {
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
     height: 16px;
     width: 16px;
+}
+
+/* due to the background svg, we cannot set the color fill, so use the invert(1) filter to swap the color */
+@media (prefers-color-scheme: dark) {
+    #main h2:hover .octicon,
+    #main h3:hover .octicon {
+        filter: invert(1);
+    }
 }
 
 /* next.js logo needs to invert color based on color scheme  */

--- a/app/assets/css/syntax.css
+++ b/app/assets/css/syntax.css
@@ -1,3 +1,49 @@
+/* Copy code button */
+.highlighter-rouge {
+    position: relative;
+}
+
+.highlighter-rouge button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    opacity: 0.5;
+    position: absolute;
+    top: 5px;
+    right: 0px;
+    z-index: 2;
+}
+
+.highlighter-rouge button.copied,
+.highlighter-rouge button:focus,
+.highlighter-rouge button:hover {
+    opacity: 1;
+}
+
+.highlighter-rouge button svg {
+    fill: var(--color-text);
+}
+
+.highlighter-rouge button::before {
+    position: absolute;
+    background: var(--color-blue-1);
+    border-radius: 3px;
+    bottom: -30px;
+    color: #fff;
+    content: 'Copied!';
+    display: none;
+    font-size: 10px;
+    opacity: 0;
+    padding: 8px;
+    right: -50%;
+    transition: opacity 0.1s ease-in;
+}
+
+.highlighter-rouge button.copied::before {
+    display: block;
+    opacity: 1;
+}
+
 /* https://github.com/jwarby/jekyll-pygments-themes/blob/master/github.css */
 .highlight {
     margin: 0 0 1em;

--- a/app/assets/js/copy-code.js
+++ b/app/assets/js/copy-code.js
@@ -1,0 +1,48 @@
+// find all code blocks on the page
+const codeBlocks = document.querySelectorAll('div.highlighter-rouge');
+
+Array.from(codeBlocks).forEach((codeBlock) => {
+    // Skip css and diff blocks as they don't need to be copied
+    if (codeBlock.classList.contains('language-css') || codeBlock.classList.contains('language-diff')) {
+        return;
+    }
+
+    // Create copy button
+    const button = document.createElement('button');
+    button.classList.add('copy-code-button');
+    button.setAttribute('aria-label', 'Copy');
+    button.setAttribute('tabindex', '0');
+    button.setAttribute('title', 'Copy to clipboard');
+    button.innerHTML =
+        '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg>';
+    codeBlock.prepend(button);
+
+    // Attach listener to button
+    button.addEventListener('click', () => {
+        // Grab code to copy
+        const codeContainer = codeBlock.querySelector('.highlight');
+        const code = codeContainer.innerText;
+
+        // Copy the code to the user's clipboard
+        window.navigator.clipboard?.writeText(code);
+
+        // Update the button content visually
+        const { innerHTML: originalHTML } = button;
+        button.innerHTML =
+            '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" fill="var(--color-success)"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>';
+        button.setAttribute('aria-label', 'Copied');
+
+        // Add slight delay to toggle the copied class
+        setTimeout(() => {
+            button.classList.add('copied');
+        }, 300);
+
+        // After 2 seconds, reset the button to its initial UI
+        setTimeout(() => {
+            button.innerHTML = originalHTML;
+            button.classList.remove('copied');
+            button.setAttribute('aria-label', 'Copy');
+            button.blur();
+        }, 2000);
+    });
+});

--- a/docs/_includes/code-header.html
+++ b/docs/_includes/code-header.html
@@ -1,0 +1,3 @@
+<div class="code-header">
+    <button class="copy-code-button">Copy code to clipboard</button>
+</div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,6 +23,7 @@
 
     <script src="/assets/js/search.js" async></script>
     <script src="/assets/js/page.js"></script>
+    <script src="/assets/js/copyCode.js"></script>
     <script>
         (function() {
             // handle docs menu toggle

--- a/docs/guides/syntax.md
+++ b/docs/guides/syntax.md
@@ -198,13 +198,21 @@ A suffix mapped to a [pseudo-element](https://developer.mozilla.org/en-US/docs/W
 -   `ph` for `::placeholder`
 -   `s` for `::selection`
 
+This example uses the `content` property to add open and closed quotes with the `::b` and `::a` pseudo-elements.
+
+```html
+<q class="Cnt(oq)::b Cnt(cq)::a">Hello world!</q>
+```
+
+<q class="Cnt(oq)::b Cnt(cq)::a Fz(20px)">Hello world!</q>
+
 ### &lt;combinator&gt;
 
 Required if &lt;context&gt; is provided. One of the following may be used:
 
 #### The underscore character (`_`)
 
-Use this to create a contextual style based on the [descendant combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/descendant).
+Use this to create a contextual style based on the [descendant combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator).
 
 ```html
 <div class="foo">
@@ -216,7 +224,7 @@ This class hides the element whenever one of its ancestor has the class `foo` at
 
 #### The right angle bracket character (`&gt;`)
 
-Use this to create a contextual style based on the [child combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/child).
+Use this to create a contextual style based on the [child combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator).
 
 Example:
 
@@ -230,7 +238,7 @@ This class hides the element if its parent has the class `foo` attached to it.
 
 #### The plus sign (`+`)
 
-Use the [adjacent sibling combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/adjacent) to style only if the immediate next sibling of an particular element.
+Use the [adjacent sibling combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_combinator) to style only if the immediate next sibling of an particular element.
 
 Example:
 

--- a/docs/guides/syntax.md
+++ b/docs/guides/syntax.md
@@ -129,6 +129,22 @@ Optional.
 
 A **class** applied to an ancestor or sibling of the node (see [examples](#examples)).
 
+```html
+<div class="foo">
+    <div class="foo:h_D(n)"></div>
+</div>
+```
+
+The above creates the following rule:
+
+```css
+.foo:hover .foo:h_D(n) {
+  display: none;
+}
+```
+
+This class hides the current element whenever its ancestor (`.foo`) is hovered over.
+
 ### &lt;pseudo-class&gt;
 
 Optional.

--- a/docs/guides/syntax.md
+++ b/docs/guides/syntax.md
@@ -204,7 +204,7 @@ This example uses the `content` property to add open and closed quotes with the 
 <q class="Cnt(oq)::b Cnt(cq)::a">Hello world!</q>
 ```
 
-<q class="Cnt(oq)::b Cnt(cq)::a Fz(20px)">Hello world!</q>
+<q class="Cnt(oq)::b Cnt(cq)::a Fz(30px)::b Fz(30px)::a Fz(20px) C(--color-blue-4)::b C(--color-blue-4)::a">Hello world!</q>
 
 ### &lt;combinator&gt;
 

--- a/docs/guides/syntax.md
+++ b/docs/guides/syntax.md
@@ -201,10 +201,10 @@ A suffix mapped to a [pseudo-element](https://developer.mozilla.org/en-US/docs/W
 This example uses the `content` property to add open and closed quotes with the `::b` and `::a` pseudo-elements.
 
 ```html
-<q class="Cnt(oq)::b Cnt(cq)::a">Hello world!</q>
+<p class="Cnt(oq)::b Cnt(cq)::a">Hello world!</p>
 ```
 
-<q class="Cnt(oq)::b Cnt(cq)::a Fz(30px)::b Fz(30px)::a Fz(20px) C(--color-blue-4)::b C(--color-blue-4)::a">Hello world!</q>
+<p class="Cnt(oq)::b Cnt(cq)::a Fz(30px)::b Fz(30px)::a Fz(20px)">Hello world!</p>
 
 ### &lt;combinator&gt;
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ Next, create a simple html file, `index.html` and copy the following HTML into i
 Run atomizer on the file to generate the CSS _(NOTE: the command will not finish because the `--watch` command is listening for changes)_:
 
 ```shell
-atomizer -o ./dist/output.css --watch index.html index.html
+atomizer -o ./dist/output.css --watch index.html
 ```
 
 A new CSS file at `./dist/output.css` will be created with the following content:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 
 const baseConfig = {
     entry: {
+        copyCode: './app/assets/js/copy-code.js',
         page: './app/assets/js/page.js',
         main: './app/client-reference.js',
         repl: './app/assets/js/repl.js',


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

Using JS to add a simple copy button to the code blocks to make it easier for users to grab the code. Took inspiration from Github's copy code feature.

![copycopy](https://user-images.githubusercontent.com/193272/190492845-f0eb6e54-db89-43b5-9ebe-32fa4e5ae3ab.gif)
