### PR TITLE
feat: remove loader-utils from webpack-atomizer-loader

### DIFF
--- a/.changeset/shaggy-horses-lay.md
+++ b/.changeset/shaggy-horses-lay.md
@@ -1,0 +1,5 @@
+---
+"webpack-atomizer-loader": major
+---
+
+feat: remove deprecated getOptions util

--- a/packages/webpack-atomizer-loader/lib/atomicLoader.ts
+++ b/packages/webpack-atomizer-loader/lib/atomicLoader.ts
@@ -2,7 +2,6 @@
 
 import Atomizer, { CSSOptions } from 'atomizer';
 import cssnano from 'cssnano';
-import { getOptions } from 'loader-utils';
 import postcss from 'postcss';
 
 import { writeCssFile, ensureExists } from './utils';
@@ -101,7 +100,7 @@ const atomicLoader = function (source, map) {
         this.cacheable();
     }
 
-    const query = getOptions(this) || {};
+    const query = this.getOptions() || {};
     const { config, configPath = [], minimize = false, postcssPlugins = [] } = query;
     const validPostcssPlugins = Array.isArray(postcssPlugins) ? postcssPlugins : DEFAULT_POSTCSS_PLUGIN_LIST;
     const addDependency = this.addDependency;

--- a/packages/webpack-atomizer-loader/package.json
+++ b/packages/webpack-atomizer-loader/package.json
@@ -24,7 +24,6 @@
     "dependencies": {
         "atomizer": "^3.9.2",
         "cssnano": "^5.0.7",
-        "loader-utils": "^2.0.0",
         "postcss": "^8.3.6"
     },
     "repository": {

--- a/packages/webpack-atomizer-loader/tests/atomicLoader.js
+++ b/packages/webpack-atomizer-loader/tests/atomicLoader.js
@@ -6,6 +6,7 @@ const stealthyRequire = require('stealthy-require');
 describe('atomic loader', () => {
     it('can generate correct css', (done) => {
         const atomicLoader = stealthyRequire(require.cache, () => require('../dist/atomicLoader'));
+        this.getOptions = () => {};
         this.async = () => () => {
             const cssReg = new RegExp(/\.Bgc\\\(yellow\\\)/);
             const cssFile = fs.readFileSync('./build/css/atomic.css');
@@ -17,6 +18,7 @@ describe('atomic loader', () => {
     it('keeps already-generated css', (done) => {
         const atomicLoader = stealthyRequire(require.cache, () => require('../dist/atomicLoader'));
         let iteration = 0;
+        this.getOptions = () => {};
         this.async = () => () => {
             if (iteration >= 1) {
                 const cssReg = new RegExp(/\.Bgc\\\(yellow\\\)/);
@@ -37,9 +39,11 @@ describe('atomic loader', () => {
             expect(cssReg.test(cssFile)).to.equal(true);
             done();
         };
-        this.query = {
+        const query = {
             configPath: path.resolve(__dirname, 'fixtures', 'rules-path.config.js'),
         };
+        this.query = query;
+        this.getOptions = () => query;
         atomicLoader.call(this, '<div class="Foo"></div>');
     });
     it('rules object', (done) => {
@@ -50,9 +54,11 @@ describe('atomic loader', () => {
             expect(cssReg.test(cssFile)).to.equal(true);
             done();
         };
-        this.query = {
+        const query = {
             configPath: path.resolve(__dirname, 'fixtures', 'rules-object.config.js'),
         };
+        this.query = query;
+        this.getOptions = () => query;
         atomicLoader.call(this, '<div class="Foo"></div>');
     });
     it('config path', (done) => {
@@ -64,9 +70,11 @@ describe('atomic loader', () => {
             expect(cssReg.test(cssFile)).to.equal(true);
             done();
         };
-        this.query = {
+        const query = {
             configPath: path.resolve(__dirname, 'fixtures', 'simple.config.js'),
         };
+        this.query = query;
+        this.getOptions = () => query;
         atomicLoader.call(this, '<div class="Bgc(foo)"></div>');
     });
 
@@ -78,12 +86,14 @@ describe('atomic loader', () => {
             expect(/\.C\\\(bar\\\)/.test(cssFile)).to.equal(true);
             done();
         };
-        this.query = {
+        const query = {
             configPath: [
                 path.resolve(__dirname, 'fixtures', 'simple.config.js'),
                 path.resolve(__dirname, 'fixtures', 'simple2.config.js'),
             ],
         };
+        this.query = query;
+        this.getOptions = () => query;
         atomicLoader.call(this, '<div class="Bgc(foo) C(bar)"></div>');
     });
 
@@ -94,7 +104,7 @@ describe('atomic loader', () => {
             expect(/\.Bgc\\\(foo\\\)/.test(cssFile)).to.equal(true);
             done();
         };
-        this.query = {
+        const query = {
             config: {
                 configs: {
                     classNames: [],
@@ -104,6 +114,8 @@ describe('atomic loader', () => {
                 },
             },
         };
+        this.query = query;
+        this.getOptions = () => query;
         atomicLoader.call(this, '<div class="Bgc(foo)"></div>');
     });
 });


### PR DESCRIPTION
getOptions was removed from loader-utils@3.x. Its part of the loader API now, so no longer need this package. Bumping major version to be safe.

Replaces https://github.com/acss-io/atomizer/pull/530