### PR TITLE
feat: add text-decoration-* rules

### DIFF
--- a/packages/atomizer/src/break.js
+++ b/packages/atomizer/src/break.js
@@ -1,0 +1,11 @@
+module.exports = {
+    a: 'auto',
+    al: 'all',
+    av: 'avoid',
+    avc: 'avoid-column',
+    avp: 'avoid-page',
+    c: 'column',
+    end: '__END__',
+    p: 'page',
+    start: '__START__',
+};

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -34,6 +34,7 @@
  **/
 const { baselinePosition, contentDistribution, contentPosition } = require('./boxAlignment');
 const blendModes = require('./blendmodes');
+const breakValues = require('./break');
 const mixBlendModes = Object.assign(blendModes, { pd: 'plus-darker', pl: 'plus-lighter' });
 const colors = require('./colors');
 const { borderStyles, borderWidths } = require('./border');
@@ -945,6 +946,49 @@ module.exports = [
         arguments: [
             {
                 n: 'none',
+            },
+        ],
+    },
+
+    /**
+    ==================================================================
+    BREAK
+    ==================================================================
+    */
+    {
+        type: 'pattern',
+        name: 'Break after',
+        matcher: 'Ba',
+        allowParamToValue: false,
+        styles: {
+            'break-after': '$0',
+        },
+        arguments: [breakValues],
+    },
+    {
+        type: 'pattern',
+        name: 'Break before',
+        matcher: 'Bf',
+        allowParamToValue: false,
+        styles: {
+            'break-before': '$0',
+        },
+        arguments: [breakValues],
+    },
+    {
+        type: 'pattern',
+        name: 'Break inside',
+        matcher: 'Bi',
+        allowParamToValue: false,
+        styles: {
+            'break-inside': '$0',
+        },
+        arguments: [
+            {
+                a: 'auto',
+                av: 'avoid',
+                avc: 'avoid-column',
+                avp: 'avoid-page',
             },
         ],
     },

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -3391,6 +3391,63 @@ module.exports = [
             },
         ],
     },
+    {
+        type: 'pattern',
+        name: 'Text decoration color',
+        matcher: 'Tdc',
+        allowParamToValue: false,
+        styles: {
+            'text-decoration-color': '$0',
+        },
+        arguments: [colors],
+    },
+    {
+        type: 'pattern',
+        name: 'Text decoration style',
+        matcher: 'Tds',
+        allowParamToValue: false,
+        styles: {
+            'text-decoration-style': '$0',
+        },
+        arguments: [
+            {
+                d: 'dotted',
+                da: 'dashed',
+                do: 'double',
+                s: 'solid',
+                w: 'wavy',
+            },
+        ],
+    },
+    {
+        type: 'pattern',
+        name: 'Text decoration thickness',
+        matcher: 'Tdt',
+        allowParamToValue: true,
+        styles: {
+            'text-decoration-thickness': '$0',
+        },
+        arguments: [
+            {
+                a: 'auto',
+                ff: 'from-font',
+            },
+        ],
+    },
+    {
+        type: 'pattern',
+        name: 'Text underline offset',
+        matcher: 'Tuo',
+        allowParamToValue: true,
+        styles: {
+            'text-underline-offset': '$0',
+        },
+        arguments: [
+            {
+                a: 'auto',
+            },
+        ],
+    },
     /**
     ==================================================================
     TEXT-INDENT

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -667,6 +667,127 @@ module.exports = [
     },
     /**
     ==================================================================
+    BACKDROP-FILTER FUNCTIONS
+    https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty
+    ==================================================================
+    */
+    // filter for custom
+    {
+        type: 'pattern',
+        name: 'Backdrop Filter',
+        matcher: 'Bkdp',
+        allowParamToValue: false,
+        styles: {
+            'backdrop-filter': '$0',
+        },
+        arguments: [
+            {
+                n: 'none',
+            },
+        ],
+    },
+    // blur
+    {
+        type: 'pattern',
+        name: 'Backdrop Blur (filter)',
+        matcher: 'BkdpBlur',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'blur($0)',
+        },
+    },
+    // brightness
+    {
+        type: 'pattern',
+        name: 'Backdrop Brightness (filter)',
+        matcher: 'BkdpBrightness',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'brightness($0)',
+        },
+    },
+    // contrast
+    {
+        type: 'pattern',
+        name: 'Backdrop Contrast (filter)',
+        matcher: 'BkdpContrast',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'contrast($0)',
+        },
+    },
+    // dropshadow
+    {
+        type: 'pattern',
+        name: 'Backdrop Drop shadow (filter)',
+        matcher: 'BkdpDropshadow',
+        allowParamToValue: false,
+        styles: {
+            'backdrop-filter': 'drop-shadow($0)',
+        },
+    },
+    // grayscale
+    {
+        type: 'pattern',
+        name: 'Backdrop Grayscale (filter)',
+        matcher: 'BkdpGrayscale',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'grayscale($0)',
+        },
+    },
+    // hue-rotate
+    {
+        type: 'pattern',
+        name: 'Backdrop Hue Rotate (filter)',
+        matcher: 'BkdpHueRotate',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'hue-rotate($0)',
+        },
+    },
+    // invert
+    {
+        type: 'pattern',
+        name: 'Backdrop Invert (filter)',
+        matcher: 'BkdpInvert',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'invert($0)',
+        },
+    },
+    // opacity
+    {
+        type: 'pattern',
+        name: 'Backdrop Opacity (filter)',
+        matcher: 'BkdpOpacity',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'opacity($0)',
+        },
+    },
+    // saturate
+    {
+        type: 'pattern',
+        name: 'Backdrop Saturate (filter)',
+        matcher: 'BkdpSaturate',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'saturate($0)',
+        },
+    },
+    // sepia
+    {
+        type: 'pattern',
+        name: 'Backdrop Sepia (filter)',
+        matcher: 'BkdpSepia',
+        allowParamToValue: true,
+        styles: {
+            'backdrop-filter': 'sepia($0)',
+        },
+    },
+    /**
+    ==================================================================
     BACKGROUNDS
     ==================================================================
     */

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -968,7 +968,7 @@ module.exports = [
     {
         type: 'pattern',
         name: 'Break before',
-        matcher: 'Bf',
+        matcher: 'Bb',
         allowParamToValue: false,
         styles: {
             'break-before': '$0',

--- a/packages/atomizer/tests/__snapshots__/rules.test.js.snap
+++ b/packages/atomizer/tests/__snapshots__/rules.test.js.snap
@@ -697,6 +697,78 @@ exports[`Rules aspect-ratio 1`] = `
 "
 `;
 
+exports[`Rules backdrop-filter 1`] = `
+".Bkdp\\(n\\) {
+  backdrop-filter: none;
+}
+"
+`;
+
+exports[`Rules backdrop-filter 2`] = `
+".BkdpBlur\\(1px\\) {
+  backdrop-filter: blur(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 3`] = `
+".BkdpBrightness\\(1px\\) {
+  backdrop-filter: brightness(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 4`] = `
+".BkdpContrast\\(1px\\) {
+  backdrop-filter: contrast(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 5`] = `""`;
+
+exports[`Rules backdrop-filter 6`] = `
+".BkdpGrayscale\\(1px\\) {
+  backdrop-filter: grayscale(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 7`] = `
+".BkdpHueRotate\\(1px\\) {
+  backdrop-filter: hue-rotate(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 8`] = `
+".BkdpInvert\\(1px\\) {
+  backdrop-filter: invert(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 9`] = `
+".BkdpOpacity\\(1px\\) {
+  backdrop-filter: opacity(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 10`] = `
+".BkdpSaturate\\(1px\\) {
+  backdrop-filter: saturate(1px);
+}
+"
+`;
+
+exports[`Rules backdrop-filter 11`] = `
+".BkdpSepia\\(1px\\) {
+  backdrop-filter: sepia(1px);
+}
+"
+`;
+
 exports[`Rules backface-visibility 1`] = `
 ".Bfv\\(h\\) {
   backface-visibility: hidden;

--- a/packages/atomizer/tests/__snapshots__/rules.test.js.snap
+++ b/packages/atomizer/tests/__snapshots__/rules.test.js.snap
@@ -8822,6 +8822,492 @@ exports[`Rules text-decoration 1`] = `
 "
 `;
 
+exports[`Rules text-decoration-color 1`] = `
+".Tdc\\(t\\) {
+  text-decoration-color: transparent;
+}
+.Tdc\\(cc\\) {
+  text-decoration-color: currentColor;
+}
+.Tdc\\(n\\) {
+  text-decoration-color: none;
+}
+.Tdc\\(aliceblue\\) {
+  text-decoration-color: aliceblue;
+}
+.Tdc\\(antiquewhite\\) {
+  text-decoration-color: antiquewhite;
+}
+.Tdc\\(aqua\\) {
+  text-decoration-color: aqua;
+}
+.Tdc\\(aquamarine\\) {
+  text-decoration-color: aquamarine;
+}
+.Tdc\\(azure\\) {
+  text-decoration-color: azure;
+}
+.Tdc\\(beige\\) {
+  text-decoration-color: beige;
+}
+.Tdc\\(bisque\\) {
+  text-decoration-color: bisque;
+}
+.Tdc\\(black\\) {
+  text-decoration-color: black;
+}
+.Tdc\\(blanchedalmond\\) {
+  text-decoration-color: blanchedalmond;
+}
+.Tdc\\(blue\\) {
+  text-decoration-color: blue;
+}
+.Tdc\\(blueviolet\\) {
+  text-decoration-color: blueviolet;
+}
+.Tdc\\(brown\\) {
+  text-decoration-color: brown;
+}
+.Tdc\\(burlywood\\) {
+  text-decoration-color: burlywood;
+}
+.Tdc\\(cadetblue\\) {
+  text-decoration-color: cadetblue;
+}
+.Tdc\\(chartreuse\\) {
+  text-decoration-color: chartreuse;
+}
+.Tdc\\(chocolate\\) {
+  text-decoration-color: chocolate;
+}
+.Tdc\\(coral\\) {
+  text-decoration-color: coral;
+}
+.Tdc\\(cornflowerblue\\) {
+  text-decoration-color: cornflowerblue;
+}
+.Tdc\\(cornsilk\\) {
+  text-decoration-color: cornsilk;
+}
+.Tdc\\(crimson\\) {
+  text-decoration-color: crimson;
+}
+.Tdc\\(cyan\\) {
+  text-decoration-color: cyan;
+}
+.Tdc\\(darkblue\\) {
+  text-decoration-color: darkblue;
+}
+.Tdc\\(darkcyan\\) {
+  text-decoration-color: darkcyan;
+}
+.Tdc\\(darkgoldenrod\\) {
+  text-decoration-color: darkgoldenrod;
+}
+.Tdc\\(darkgray\\) {
+  text-decoration-color: darkgray;
+}
+.Tdc\\(darkgreen\\) {
+  text-decoration-color: darkgreen;
+}
+.Tdc\\(darkgrey\\) {
+  text-decoration-color: darkgrey;
+}
+.Tdc\\(darkkhaki\\) {
+  text-decoration-color: darkkhaki;
+}
+.Tdc\\(darkmagenta\\) {
+  text-decoration-color: darkmagenta;
+}
+.Tdc\\(darkolivegreen\\) {
+  text-decoration-color: darkolivegreen;
+}
+.Tdc\\(darkorange\\) {
+  text-decoration-color: darkorange;
+}
+.Tdc\\(darkorchid\\) {
+  text-decoration-color: darkorchid;
+}
+.Tdc\\(darkred\\) {
+  text-decoration-color: darkred;
+}
+.Tdc\\(darksalmon\\) {
+  text-decoration-color: darksalmon;
+}
+.Tdc\\(darkseagreen\\) {
+  text-decoration-color: darkseagreen;
+}
+.Tdc\\(darkslateblue\\) {
+  text-decoration-color: darkslateblue;
+}
+.Tdc\\(darkslategray\\) {
+  text-decoration-color: darkslategray;
+}
+.Tdc\\(darkslategrey\\) {
+  text-decoration-color: darkslategrey;
+}
+.Tdc\\(darkturquoise\\) {
+  text-decoration-color: darkturquoise;
+}
+.Tdc\\(darkviolet\\) {
+  text-decoration-color: darkviolet;
+}
+.Tdc\\(deeppink\\) {
+  text-decoration-color: deeppink;
+}
+.Tdc\\(deepskyblue\\) {
+  text-decoration-color: deepskyblue;
+}
+.Tdc\\(dimgray\\) {
+  text-decoration-color: dimgray;
+}
+.Tdc\\(dimgrey\\) {
+  text-decoration-color: dimgrey;
+}
+.Tdc\\(dodgerblue\\) {
+  text-decoration-color: dodgerblue;
+}
+.Tdc\\(firebrick\\) {
+  text-decoration-color: firebrick;
+}
+.Tdc\\(floralwhite\\) {
+  text-decoration-color: floralwhite;
+}
+.Tdc\\(forestgreen\\) {
+  text-decoration-color: forestgreen;
+}
+.Tdc\\(fuchsia\\) {
+  text-decoration-color: fuchsia;
+}
+.Tdc\\(gainsboro\\) {
+  text-decoration-color: gainsboro;
+}
+.Tdc\\(ghostwhite\\) {
+  text-decoration-color: ghostwhite;
+}
+.Tdc\\(gold\\) {
+  text-decoration-color: gold;
+}
+.Tdc\\(goldenrod\\) {
+  text-decoration-color: goldenrod;
+}
+.Tdc\\(gray\\) {
+  text-decoration-color: gray;
+}
+.Tdc\\(green\\) {
+  text-decoration-color: green;
+}
+.Tdc\\(greenyellow\\) {
+  text-decoration-color: greenyellow;
+}
+.Tdc\\(grey\\) {
+  text-decoration-color: grey;
+}
+.Tdc\\(honeydew\\) {
+  text-decoration-color: honeydew;
+}
+.Tdc\\(hotpink\\) {
+  text-decoration-color: hotpink;
+}
+.Tdc\\(indianred\\) {
+  text-decoration-color: indianred;
+}
+.Tdc\\(indigo\\) {
+  text-decoration-color: indigo;
+}
+.Tdc\\(ivory\\) {
+  text-decoration-color: ivory;
+}
+.Tdc\\(khaki\\) {
+  text-decoration-color: khaki;
+}
+.Tdc\\(lavender\\) {
+  text-decoration-color: lavender;
+}
+.Tdc\\(lavenderblush\\) {
+  text-decoration-color: lavenderblush;
+}
+.Tdc\\(lawngreen\\) {
+  text-decoration-color: lawngreen;
+}
+.Tdc\\(lemonchiffon\\) {
+  text-decoration-color: lemonchiffon;
+}
+.Tdc\\(lightblue\\) {
+  text-decoration-color: lightblue;
+}
+.Tdc\\(lightcoral\\) {
+  text-decoration-color: lightcoral;
+}
+.Tdc\\(lightcyan\\) {
+  text-decoration-color: lightcyan;
+}
+.Tdc\\(lightgoldenrodyellow\\) {
+  text-decoration-color: lightgoldenrodyellow;
+}
+.Tdc\\(lightgray\\) {
+  text-decoration-color: lightgray;
+}
+.Tdc\\(lightgreen\\) {
+  text-decoration-color: lightgreen;
+}
+.Tdc\\(lightgrey\\) {
+  text-decoration-color: lightgrey;
+}
+.Tdc\\(lightpink\\) {
+  text-decoration-color: lightpink;
+}
+.Tdc\\(lightsalmon\\) {
+  text-decoration-color: lightsalmon;
+}
+.Tdc\\(lightseagreen\\) {
+  text-decoration-color: lightseagreen;
+}
+.Tdc\\(lightskyblue\\) {
+  text-decoration-color: lightskyblue;
+}
+.Tdc\\(lightslategray\\) {
+  text-decoration-color: lightslategray;
+}
+.Tdc\\(lightslategrey\\) {
+  text-decoration-color: lightslategrey;
+}
+.Tdc\\(lightsteelblue\\) {
+  text-decoration-color: lightsteelblue;
+}
+.Tdc\\(lightyellow\\) {
+  text-decoration-color: lightyellow;
+}
+.Tdc\\(lime\\) {
+  text-decoration-color: lime;
+}
+.Tdc\\(limegreen\\) {
+  text-decoration-color: limegreen;
+}
+.Tdc\\(linen\\) {
+  text-decoration-color: linen;
+}
+.Tdc\\(magenta\\) {
+  text-decoration-color: magenta;
+}
+.Tdc\\(maroon\\) {
+  text-decoration-color: maroon;
+}
+.Tdc\\(mediumaquamarine\\) {
+  text-decoration-color: mediumaquamarine;
+}
+.Tdc\\(mediumblue\\) {
+  text-decoration-color: mediumblue;
+}
+.Tdc\\(mediumorchid\\) {
+  text-decoration-color: mediumorchid;
+}
+.Tdc\\(mediumpurple\\) {
+  text-decoration-color: mediumpurple;
+}
+.Tdc\\(mediumseagreen\\) {
+  text-decoration-color: mediumseagreen;
+}
+.Tdc\\(mediumslateblue\\) {
+  text-decoration-color: mediumslateblue;
+}
+.Tdc\\(mediumspringgreen\\) {
+  text-decoration-color: mediumspringgreen;
+}
+.Tdc\\(mediumturquoise\\) {
+  text-decoration-color: mediumturquoise;
+}
+.Tdc\\(mediumvioletred\\) {
+  text-decoration-color: mediumvioletred;
+}
+.Tdc\\(midnightblue\\) {
+  text-decoration-color: midnightblue;
+}
+.Tdc\\(mintcream\\) {
+  text-decoration-color: mintcream;
+}
+.Tdc\\(mistyrose\\) {
+  text-decoration-color: mistyrose;
+}
+.Tdc\\(moccasin\\) {
+  text-decoration-color: moccasin;
+}
+.Tdc\\(navajowhite\\) {
+  text-decoration-color: navajowhite;
+}
+.Tdc\\(navy\\) {
+  text-decoration-color: navy;
+}
+.Tdc\\(oldlace\\) {
+  text-decoration-color: oldlace;
+}
+.Tdc\\(olive\\) {
+  text-decoration-color: olive;
+}
+.Tdc\\(olivedrab\\) {
+  text-decoration-color: olivedrab;
+}
+.Tdc\\(orange\\) {
+  text-decoration-color: orange;
+}
+.Tdc\\(orangered\\) {
+  text-decoration-color: orangered;
+}
+.Tdc\\(orchid\\) {
+  text-decoration-color: orchid;
+}
+.Tdc\\(palegoldenrod\\) {
+  text-decoration-color: palegoldenrod;
+}
+.Tdc\\(palegreen\\) {
+  text-decoration-color: palegreen;
+}
+.Tdc\\(paleturquoise\\) {
+  text-decoration-color: paleturquoise;
+}
+.Tdc\\(palevioletred\\) {
+  text-decoration-color: palevioletred;
+}
+.Tdc\\(papayawhip\\) {
+  text-decoration-color: papayawhip;
+}
+.Tdc\\(peachpuff\\) {
+  text-decoration-color: peachpuff;
+}
+.Tdc\\(peru\\) {
+  text-decoration-color: peru;
+}
+.Tdc\\(pink\\) {
+  text-decoration-color: pink;
+}
+.Tdc\\(plum\\) {
+  text-decoration-color: plum;
+}
+.Tdc\\(powderblue\\) {
+  text-decoration-color: powderblue;
+}
+.Tdc\\(purple\\) {
+  text-decoration-color: purple;
+}
+.Tdc\\(red\\) {
+  text-decoration-color: red;
+}
+.Tdc\\(rosybrown\\) {
+  text-decoration-color: rosybrown;
+}
+.Tdc\\(royalblue\\) {
+  text-decoration-color: royalblue;
+}
+.Tdc\\(saddlebrown\\) {
+  text-decoration-color: saddlebrown;
+}
+.Tdc\\(salmon\\) {
+  text-decoration-color: salmon;
+}
+.Tdc\\(sandybrown\\) {
+  text-decoration-color: sandybrown;
+}
+.Tdc\\(seagreen\\) {
+  text-decoration-color: seagreen;
+}
+.Tdc\\(seashell\\) {
+  text-decoration-color: seashell;
+}
+.Tdc\\(sienna\\) {
+  text-decoration-color: sienna;
+}
+.Tdc\\(silver\\) {
+  text-decoration-color: silver;
+}
+.Tdc\\(skyblue\\) {
+  text-decoration-color: skyblue;
+}
+.Tdc\\(slateblue\\) {
+  text-decoration-color: slateblue;
+}
+.Tdc\\(slategray\\) {
+  text-decoration-color: slategray;
+}
+.Tdc\\(slategrey\\) {
+  text-decoration-color: slategrey;
+}
+.Tdc\\(snow\\) {
+  text-decoration-color: snow;
+}
+.Tdc\\(springgreen\\) {
+  text-decoration-color: springgreen;
+}
+.Tdc\\(steelblue\\) {
+  text-decoration-color: steelblue;
+}
+.Tdc\\(tan\\) {
+  text-decoration-color: tan;
+}
+.Tdc\\(teal\\) {
+  text-decoration-color: teal;
+}
+.Tdc\\(thistle\\) {
+  text-decoration-color: thistle;
+}
+.Tdc\\(tomato\\) {
+  text-decoration-color: tomato;
+}
+.Tdc\\(turquoise\\) {
+  text-decoration-color: turquoise;
+}
+.Tdc\\(violet\\) {
+  text-decoration-color: violet;
+}
+.Tdc\\(wheat\\) {
+  text-decoration-color: wheat;
+}
+.Tdc\\(white\\) {
+  text-decoration-color: white;
+}
+.Tdc\\(whitesmoke\\) {
+  text-decoration-color: whitesmoke;
+}
+.Tdc\\(yellow\\) {
+  text-decoration-color: yellow;
+}
+.Tdc\\(yellowgreen\\) {
+  text-decoration-color: yellowgreen;
+}
+"
+`;
+
+exports[`Rules text-decoration-style 1`] = `
+".Tds\\(d\\) {
+  text-decoration-style: dotted;
+}
+.Tds\\(da\\) {
+  text-decoration-style: dashed;
+}
+.Tds\\(do\\) {
+  text-decoration-style: double;
+}
+.Tds\\(s\\) {
+  text-decoration-style: solid;
+}
+.Tds\\(w\\) {
+  text-decoration-style: wavy;
+}
+"
+`;
+
+exports[`Rules text-decoration-thickness 1`] = `
+".Tdt\\(a\\) {
+  text-decoration-thickness: auto;
+}
+.Tdt\\(ff\\) {
+  text-decoration-thickness: from-font;
+}
+.Tdt\\(1px\\) {
+  text-decoration-thickness: 1px;
+}
+"
+`;
+
 exports[`Rules text-indent 1`] = `
 ".Ti\\(1px\\) {
   text-indent: 1px;
@@ -8881,6 +9367,16 @@ exports[`Rules text-transform 1`] = `
 }
 .Tt\\(l\\) {
   text-transform: lowercase;
+}
+"
+`;
+
+exports[`Rules text-underline-offset 1`] = `
+".Tuo\\(a\\) {
+  text-underline-offset: auto;
+}
+.Tuo\\(1px\\) {
+  text-underline-offset: 1px;
 }
 "
 `;

--- a/packages/atomizer/tests/__snapshots__/rules.test.js.snap
+++ b/packages/atomizer/tests/__snapshots__/rules.test.js.snap
@@ -4136,31 +4136,31 @@ exports[`Rules break-after 1`] = `
 `;
 
 exports[`Rules break-before 1`] = `
-".Bf\\(a\\) {
+".Bb\\(a\\) {
   break-before: auto;
 }
-.Bf\\(al\\) {
+.Bb\\(al\\) {
   break-before: all;
 }
-.Bf\\(av\\) {
+.Bb\\(av\\) {
   break-before: avoid;
 }
-.Bf\\(avc\\) {
+.Bb\\(avc\\) {
   break-before: avoid-column;
 }
-.Bf\\(avp\\) {
+.Bb\\(avp\\) {
   break-before: avoid-page;
 }
-.Bf\\(c\\) {
+.Bb\\(c\\) {
   break-before: column;
 }
-.Bf\\(end\\) {
+.Bb\\(end\\) {
   break-before: right;
 }
-.Bf\\(p\\) {
+.Bb\\(p\\) {
   break-before: page;
 }
-.Bf\\(start\\) {
+.Bb\\(start\\) {
   break-before: left;
 }
 "

--- a/packages/atomizer/tests/__snapshots__/rules.test.js.snap
+++ b/packages/atomizer/tests/__snapshots__/rules.test.js.snap
@@ -4104,6 +4104,84 @@ exports[`Rules box-sizing 1`] = `
 "
 `;
 
+exports[`Rules break-after 1`] = `
+".Ba\\(a\\) {
+  break-after: auto;
+}
+.Ba\\(al\\) {
+  break-after: all;
+}
+.Ba\\(av\\) {
+  break-after: avoid;
+}
+.Ba\\(avc\\) {
+  break-after: avoid-column;
+}
+.Ba\\(avp\\) {
+  break-after: avoid-page;
+}
+.Ba\\(c\\) {
+  break-after: column;
+}
+.Ba\\(end\\) {
+  break-after: right;
+}
+.Ba\\(p\\) {
+  break-after: page;
+}
+.Ba\\(start\\) {
+  break-after: left;
+}
+"
+`;
+
+exports[`Rules break-before 1`] = `
+".Bf\\(a\\) {
+  break-before: auto;
+}
+.Bf\\(al\\) {
+  break-before: all;
+}
+.Bf\\(av\\) {
+  break-before: avoid;
+}
+.Bf\\(avc\\) {
+  break-before: avoid-column;
+}
+.Bf\\(avp\\) {
+  break-before: avoid-page;
+}
+.Bf\\(c\\) {
+  break-before: column;
+}
+.Bf\\(end\\) {
+  break-before: right;
+}
+.Bf\\(p\\) {
+  break-before: page;
+}
+.Bf\\(start\\) {
+  break-before: left;
+}
+"
+`;
+
+exports[`Rules break-inside 1`] = `
+".Bi\\(a\\) {
+  break-inside: auto;
+}
+.Bi\\(av\\) {
+  break-inside: avoid;
+}
+.Bi\\(avc\\) {
+  break-inside: avoid-column;
+}
+.Bi\\(avp\\) {
+  break-inside: avoid-page;
+}
+"
+`;
+
 exports[`Rules caret-color 1`] = `
 ".Cac\\(a\\) {
   caret-color: auto;


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

This PR adds the remaining CSS rules to minimally match what Tailwind supports today. There are hundreds more that can be added but at least aligns up better with other contemporaries.

- text-decoration-*
- break-*
- backdrop-filter: *
