### PR TITLE
fix(atomizer): run findFiles on bin args

### DIFF
--- a/.changeset/gorgeous-garlics-heal.md
+++ b/.changeset/gorgeous-garlics-heal.md
@@ -1,0 +1,5 @@
+---
+"atomizer": patch
+---
+
+fix(atomizer): run findFiles on bin args

--- a/packages/atomizer/bin/atomizer
+++ b/packages/atomizer/bin/atomizer
@@ -62,7 +62,7 @@ if (empty(config) && process.argv.length <= 2) {
 var filesToParse = program.args || [];
 
 // Add more src files from "content" property of config
-filesToParse = filesToParse.concat(findFiles(config.content));
+filesToParse = findFiles(filesToParse.concat(config.content || []));
 
 // Run atomizer build, output to stdout if css returned
 function runAtomizer(files, config = {}, options = {}, done) {

--- a/packages/atomizer/tests/bin/__snapshots__/atomizer.test.js.snap
+++ b/packages/atomizer/tests/bin/__snapshots__/atomizer.test.js.snap
@@ -85,6 +85,21 @@ exports[`atomizer options --rules 1`] = `
 "
 `;
 
+exports[`atomizer should parse glob patterns 1`] = `
+"
+.D\\(b\\) {
+  display: block;
+}
+.StretchedBox {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+"
+`;
+
 exports[`atomizer should parse html files for classes 1`] = `
 "
 .D\\(b\\) {

--- a/packages/atomizer/tests/bin/atomizer.test.js
+++ b/packages/atomizer/tests/bin/atomizer.test.js
@@ -9,6 +9,7 @@ const atomizer = path.resolve(__dirname, '..', '..', 'bin', 'atomizer');
 const execFileAsync = util.promisify(childProcess.execFile);
 const fixtureDir = path.resolve(__dirname, '..', 'fixtures');
 const htmlFixture = path.resolve(fixtureDir, 'test.html');
+const htmlFixtureGlob = path.resolve(fixtureDir, '*.html');
 
 describe('atomizer', () => {
     it('should return the help menu', async () => {
@@ -18,6 +19,11 @@ describe('atomizer', () => {
 
     it('should parse html files for classes', async () => {
         const { stdout } = await execFileAsync('node', [atomizer, htmlFixture]);
+        expect(stdout).toMatchSnapshot();
+    });
+
+    it('should parse glob patterns', async () => {
+        const { stdout } = await execFileAsync('node', [atomizer, htmlFixtureGlob]);
         expect(stdout).toMatchSnapshot();
     });
 


### PR DESCRIPTION
<!-- The following statement must stay in the PR description -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

After my previous refactoring, I noticed that glob path arguments passed into the binary were not expanded properly which threw an error. Now both binary arguments and config file .custom property glob patterns are properly expanded.
