### PR TITLE
chore(atomizer): update glob and minimatch to latest

### DIFF
--- a/.changeset/eight-scissors-arrive.md
+++ b/.changeset/eight-scissors-arrive.md
@@ -1,0 +1,5 @@
+---
+"atomizer": minor
+---
+
+chore(atomizer): update glob and minimatch to latest versions

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "file-saver": "^2.0.5",
         "fluxible": "^1.4.2",
         "fluxible-addons-react": "^1.2.0",
-        "glob": "^8.0.3",
+        "glob": "^10.0.0",
         "grunt": "^1.5.3",
         "grunt-cli": "^1.4.3",
         "grunt-contrib-clean": "^2.0.0",

--- a/packages/atomizer/package.json
+++ b/packages/atomizer/package.json
@@ -39,7 +39,7 @@
         "chalk": "^4.0.0",
         "chokidar": "^3.5.3",
         "commander": "^10.0.0",
-        "glob": "^8.0.3",
+        "glob": "^10.0.0",
         "lodash": "^4.17.21",
         "minimatch": "^6.1.5",
         "xregexp": "^5.1.0"

--- a/packages/atomizer/package.json
+++ b/packages/atomizer/package.json
@@ -41,7 +41,7 @@
         "commander": "^10.0.0",
         "glob": "^10.0.0",
         "lodash": "^4.17.21",
-        "minimatch": "^6.1.5",
+        "minimatch": "^9.0.0",
         "xregexp": "^5.1.0"
     },
     "repository": {

--- a/scripts/buildSearch.mjs
+++ b/scripts/buildSearch.mjs
@@ -8,7 +8,7 @@
  */
 
 import fs from 'fs';
-import glob from 'glob';
+import { sync } from 'glob';
 import lodash from 'lodash';
 import lunr from 'lunr';
 import { marked } from 'marked';
@@ -75,7 +75,7 @@ const globOpts = {
     cwd: DOCS_PATH,
     ignore: ['**/index.md', '404.md', 'README.md'],
 };
-const files = glob.sync(pattern, globOpts);
+const files = sync(pattern, globOpts);
 
 // setup index
 const index = lunr(function () {


### PR DESCRIPTION
No real changes besides only supporting Node 16 and removing default exports from the import package.