### PR TITLE
Add word-wrap: anywhere support

### DIFF
--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -4430,7 +4430,7 @@ module.exports = [
             {
                 bw: 'break-word',
                 n: 'normal',
-                a: 'anywhere'
+                a: 'anywhere',
             },
         ],
     },

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -4428,9 +4428,9 @@ module.exports = [
         },
         arguments: [
             {
+                a: 'anywhere',
                 bw: 'break-word',
                 n: 'normal',
-                a: 'anywhere',
             },
         ],
     },

--- a/packages/atomizer/src/rules.js
+++ b/packages/atomizer/src/rules.js
@@ -4430,6 +4430,7 @@ module.exports = [
             {
                 bw: 'break-word',
                 n: 'normal',
+                a: 'anywhere'
             },
         ],
     },

--- a/packages/atomizer/tests/__snapshots__/rules.test.js.snap
+++ b/packages/atomizer/tests/__snapshots__/rules.test.js.snap
@@ -10027,14 +10027,14 @@ exports[`Rules word-break 1`] = `
 `;
 
 exports[`Rules word-wrap 1`] = `
-".Wow\\(bw\\) {
+".Wow\\(a\\) {
+  word-wrap: anywhere;
+}
+.Wow\\(bw\\) {
   word-wrap: break-word;
 }
 .Wow\\(n\\) {
   word-wrap: normal;
-}
-.Wow\\(a\\) {
-  word-wrap: anywhere;
 }
 "
 `;

--- a/packages/atomizer/tests/__snapshots__/rules.test.js.snap
+++ b/packages/atomizer/tests/__snapshots__/rules.test.js.snap
@@ -10033,6 +10033,9 @@ exports[`Rules word-wrap 1`] = `
 .Wow\\(n\\) {
   word-wrap: normal;
 }
+.Wow\\(a\\) {
+  word-wrap: anywhere;
+}
 "
 `;
 


### PR DESCRIPTION
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

Adds support for `word-wrap: anywhere` - https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

### Motivation and Context

Adds support for a supported value of word-wrap

### How Has This Been Tested?

Snapshots have been updated.

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Review the following points, and put an x in all the boxes that apply. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help!

-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/acss-io/atomizer/blob/main/CONTRIBUTING.md) document.
-   [x] I have added tests to cover my changes.
