### PR TITLE
Fix postcss atomizer to avoid duplicate CSS

### DIFF
--- a/.changeset/metal-flies-look.md
+++ b/.changeset/metal-flies-look.md
@@ -1,0 +1,5 @@
+---
+"postcss-atomizer": patch
+---
+
+BREAKING CHANGE: postcss atomizer to avoid duplicate CSS

--- a/.changeset/metal-flies-look.md
+++ b/.changeset/metal-flies-look.md
@@ -1,5 +1,5 @@
 ---
-"postcss-atomizer": patch
+"postcss-atomizer": major
 ---
 
-BREAKING CHANGE: postcss atomizer to avoid duplicate CSS
+fix: postcss atomizer to avoid duplicate CSS

--- a/docs/integrations/nextjs.md
+++ b/docs/integrations/nextjs.md
@@ -55,6 +55,22 @@ module.exports = {
 
 <p class="noteBox info">Plugin options are available in the <a href="https://github.com/acss-io/atomizer/tree/main/packages/postcss-atomizer">postcss-atomizer</a> README.</p>
 
+## Create the atomizer css file
+
+```css
+/* atomizer.css */
+@atomizer;
+```
+
+## Reference the atomizer.css from your Layout
+
+Update the `./src/app/layout.js` to use the Atomizer css
+
+```js
+import './atomizer.css';
+// ...
+```
+
 ## Begin using Atomizer
 
 Update the `./src/app/page.js` file to start adding Atomizer classes to your code base.

--- a/docs/integrations/postcss.md
+++ b/docs/integrations/postcss.md
@@ -30,6 +30,13 @@ module.exports = {
 
 <p class="noteBox info">Option information and an example is available in the <a href="https://github.com/acss-io/atomizer/tree/main/packages/postcss-atomizer">postcss-atomizer</a> repository.</p>
 
+## Add Atomizer to your main.css file
+
+```css
+/* main.css */
+@atomizer;
+```
+
 ## Start your dev setup
 
 Run your build setup as configured in your project's `./package.json`.

--- a/packages/postcss-atomizer/README.md
+++ b/packages/postcss-atomizer/README.md
@@ -23,6 +23,13 @@ module.exports = {
 };
 ```
 
+Add a css file for where atomic styling will live
+
+```css
+/* atomizer.css */
+@atomizer;
+```
+
 The plugin will automatically execute Atomizer based on your project's [`atomizer.config.js`](https://acss-io.github.io/atomizer/configuration.html) file and pass the rendered CSS to any additional plugins you configure.
 
 ### Options

--- a/packages/postcss-atomizer/README.md
+++ b/packages/postcss-atomizer/README.md
@@ -23,7 +23,7 @@ module.exports = {
 };
 ```
 
-Add a css file for where atomic styling will live
+Create a css file for the generated atomizer CSS:
 
 ```css
 /* atomizer.css */

--- a/packages/postcss-atomizer/example/__tests__/postcss.test.js
+++ b/packages/postcss-atomizer/example/__tests__/postcss.test.js
@@ -4,7 +4,7 @@ const { join } = require('path');
 
 describe('postcss', () => {
     it('should create post css', async () => {
-        const input = '/* dummy test */';
+        const input = '/* dummy test */@atomizer';
         const output = '';
         const atomizer = atomizerPlugin({
             config: join(__dirname, '..', 'atomizer.config.js'),

--- a/packages/postcss-atomizer/example/main.css
+++ b/packages/postcss-atomizer/example/main.css
@@ -1,1 +1,2 @@
 /* Stub css file for postcss */
+@atomizer;

--- a/packages/postcss-atomizer/package.json
+++ b/packages/postcss-atomizer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "postcss-atomizer",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "description": "PostCSS Atomizer plugin",
     "keywords": [
         "atomizer",

--- a/packages/postcss-atomizer/package.json
+++ b/packages/postcss-atomizer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "postcss-atomizer",
-    "version": "2.0.0",
+    "version": "1.0.2",
     "description": "PostCSS Atomizer plugin",
     "keywords": [
         "atomizer",

--- a/packages/postcss-atomizer/src/index.js
+++ b/packages/postcss-atomizer/src/index.js
@@ -12,21 +12,23 @@ module.exports = (options = {}) => {
     return {
         postcssPlugin: 'postcss-atomizer',
         Root(root, { result }) {
-            const config = getConfig(finalOptions.config);
-            const files = findFiles(config.content);
+            root.walkAtRules('atomizer', atRule => {
+                const config = getConfig(finalOptions.config);
+                const files = findFiles(config.content);
 
-            // register dependency so atomizer is re-run when the file changes
-            // @see https://postcss.org/docs/writing-a-postcss-plugin#step-change-nodes
-            for (const file of files) {
-                result.messages.push({
-                    file: resolve(file),
-                    parent: result.opts.from,
-                    plugin: 'atomizer',
-                    type: 'dependency',
-                });
-            }
+                // register dependency so atomizer is re-run when the file changes
+                // @see https://postcss.org/docs/writing-a-postcss-plugin#step-change-nodes
+                for (const file of files) {
+                    result.messages.push({
+                        file: resolve(file),
+                        parent: result.opts.from,
+                        plugin: 'atomizer',
+                        type: 'dependency',
+                    });
+                }
 
-            root.append(buildAtomicCss(files, config, finalOptions));
+                atRule.replaceWith(buildAtomicCss(files, config, finalOptions));
+            });
         },
     };
 };

--- a/packages/postcss-atomizer/src/index.js
+++ b/packages/postcss-atomizer/src/index.js
@@ -12,7 +12,7 @@ module.exports = (options = {}) => {
     return {
         postcssPlugin: 'postcss-atomizer',
         Root(root, { result }) {
-            root.walkAtRules('atomizer', atRule => {
+            root.walkAtRules('atomizer', (atRule) => {
                 const config = getConfig(finalOptions.config);
                 const files = findFiles(config.content);
 


### PR DESCRIPTION
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

### Description

Fix `postcss-atomizer` so that you can control which css file and where the CSS is added.

### Motivation and Context

Currently the atomizer css is added to every single file processed by postcss, this can cause duplication if you have many css files in your project. This change allows you to control which file and where the generated css will go.

### How Has This Been Tested?

In an environment containing multiple css files I confirmed that the atomizer CSS is only added to css files where the `@atomizer;` rule is.

### Types of changes

What types of changes does your code introduce? Put an x in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

Review the following points, and put an x in all the boxes that apply. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help!

-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/acss-io/atomizer/blob/main/CONTRIBUTING.md) document.
-   [ ] I have added tests to cover my changes.
